### PR TITLE
Ft fast evaluate derivatives

### DIFF
--- a/src/bezier_spline.hpp
+++ b/src/bezier_spline.hpp
@@ -32,6 +32,7 @@ SOFTWARE.
 #include <vector>
 
 #include "bezman/src/point.hpp"
+#include "bezman/src/utils/algorithms/bernstein_polynomial.hpp"
 #include "bezman/src/utils/fastbinomialcoefficient.hpp"
 #include "bezman/src/utils/logger.hpp"
 #include "bezman/src/utils/type_traits/is_bezier_spline.hpp"

--- a/src/bezier_spline.hpp
+++ b/src/bezier_spline.hpp
@@ -259,10 +259,22 @@ class BezierSpline {
   constexpr std::array<std::vector<ScalarType>, parametric_dimension>
   BasisFunctions(const PointTypeParametric_& par_coords) const;
 
+  /// Evaluate Basis Functions Derivatives
+  constexpr std::array<std::vector<ScalarType>, parametric_dimension>
+  BasisFunctionsDerivatives(
+      const PointTypeParametric_& par_coords,
+      const std::array<std::size_t, parametric_dimension>& nth_derivs) const;
+
   /// Evaluate the spline via the explicit precomputation of bernstein
   /// values
   constexpr PhysicalPointType_ ForwardEvaluate(
       const PointTypeParametric_& par_coords) const;
+
+  /// Evaluate the derivatives of a spline via the explicit precomputation of
+  /// bernstein polynomial derivativs
+  constexpr PhysicalPointType_ EvaluateDerivative(
+      const PointTypeParametric_& par_coords,
+      const std::array<std::size_t, parametric_dimension>& nth_derivs) const;
 
   /// Evaluate the spline using explicit precomputation of bernstein values
   template <typename... T>

--- a/src/bezier_spline.inc
+++ b/src/bezier_spline.inc
@@ -317,7 +317,7 @@ constexpr PhysicalPointType BezierSpline<
     ScalarType>::ForwardEvaluate(const PointTypeParametric_& par_coords) const {
   /*
    * Here we avoid Point operations and try to precompute as many values as
-   * possible, this greatly increases the complexity of the necessary code.
+   * possible, this greatly decreases the complexity of the necessary code.
    */
   const auto factors = BasisFunctions(par_coords);
 
@@ -359,7 +359,7 @@ BezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
         const std::array<std::size_t, parametric_dimension>& nth_derivs) const {
   /*
    * Here we avoid Point operations and try to precompute as many values as
-   * possible, this greatly increases the complexity of the necessary code.
+   * possible, this greatly decreases the complexity of the necessary code.
    */
   const auto factors = BasisFunctionsDerivatives(par_coords, nth_derivs);
 

--- a/src/bezier_spline.inc
+++ b/src/bezier_spline.inc
@@ -302,29 +302,9 @@ BezierSpline<parametric_dimension, PhysicalPointType,
 
   // Preallocate space to vectors
   for (IndexingType par_dim{0}; par_dim < parametric_dimension; par_dim++) {
-    factors[par_dim].reserve(degrees[par_dim] + 1);
-  }
-
-  // Loop over parametric dimensions to precalculate basisfunctions
-  for (IndexingType par_dim{0}; par_dim < parametric_dimension; par_dim++) {
-    ScalarType_ cfactor = static_cast<ScalarType>(1.);
-    const ScalarType_ t_value = par_coords[par_dim];
-    const ScalarType_ inv_t_value = 1. - par_coords[par_dim];
-    const IndexingType c_degree = degrees[par_dim];
-    // Loop over dimensionwise ctps
-    for (IndexingType i_ctps{0}; i_ctps < c_degree + 1; i_ctps++) {
-      factors[par_dim].push_back(
-          static_cast<ScalarType>(
-              utils::FastBinomialCoefficient::choose(c_degree, i_ctps)) *
-          cfactor);
-      cfactor *= t_value;
-    }
-    // Backwards assignment
-    cfactor = static_cast<ScalarType>(1.);
-    for (IndexingType i_ctps{0}; i_ctps < c_degree + 1; i_ctps++) {
-      factors[par_dim][c_degree - i_ctps] *= cfactor;
-      cfactor *= inv_t_value;
-    }
+    factors[par_dim] =
+        utils::algorithms::BernsteinPolynomial<ScalarType>::Evaluate(
+            degrees[par_dim], par_coords[par_dim]);
   }
 
   return factors;

--- a/src/bezier_spline.inc
+++ b/src/bezier_spline.inc
@@ -333,6 +333,48 @@ constexpr PhysicalPointType BezierSpline<
 
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
+constexpr std::array<std::vector<ScalarType>, parametric_dimension>
+BezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
+    BasisFunctionsDerivatives(
+        const PointTypeParametric_& par_coords,
+        const std::array<std::size_t, parametric_dimension>& nth_derivs) const {
+  std::array<std::vector<ScalarType>, parametric_dimension> factors;
+
+  // Preallocate space to vectors
+  for (IndexingType par_dim{0}; par_dim < parametric_dimension; par_dim++) {
+    factors[par_dim] =
+        utils::algorithms::BernsteinPolynomial<ScalarType>::EvaluateDerivative(
+            degrees[par_dim], par_coords[par_dim], nth_derivs[par_dim]);
+  }
+
+  return factors;
+}
+
+template <std::size_t parametric_dimension, typename PhysicalPointType,
+          typename ScalarType>
+constexpr PhysicalPointType
+BezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
+    EvaluateDerivative(
+        const PointTypeParametric_& par_coords,
+        const std::array<std::size_t, parametric_dimension>& nth_derivs) const {
+  /*
+   * Here we avoid Point operations and try to precompute as many values as
+   * possible, this greatly increases the complexity of the necessary code.
+   */
+  const auto factors = BasisFunctionsDerivatives(par_coords, nth_derivs);
+
+  /*
+   * Now that all values have been precomputed we have to sum up the
+   * individual contributions using (compile-time) recursion
+   */
+  PhysicalPointType_ evaluation_point{};
+
+  return AddUpContributionsToControlPointVector_(evaluation_point, factors,
+                                                 static_cast<ScalarType>(1.));
+}
+
+template <std::size_t parametric_dimension, typename PhysicalPointType,
+          typename ScalarType>
 template <typename... Indices>
 constexpr PhysicalPointType
 BezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::

--- a/src/rational_bezier_spline.hpp
+++ b/src/rational_bezier_spline.hpp
@@ -294,6 +294,11 @@ class RationalBezierSpline {
     return ForwardEvaluate(PointTypeParametric_{par_coords...});
   }
 
+  /// Evaluate the derivatives of a spline using Leibnitz' rule
+  constexpr PhysicalPointType_ EvaluateDerivative(
+      const PointTypeParametric_& par_coords,
+      const std::array<std::size_t, parametric_dimension>& nth_derivs) const;
+
   //-------------------  Refinement Strategies
 
   /// Order elevation along a specific parametric dimension

--- a/src/rational_bezier_spline.inc
+++ b/src/rational_bezier_spline.inc
@@ -198,8 +198,11 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
     EvaluateDerivative(
         const PointTypeParametric_& par_coords,
         const std::array<std::size_t, parametric_dimension>& nth_derivs) const {
-  // Define Lambdas for indexing
-  // From a single index notation to an array of indices
+  // Define lambdas to switch between local indexing with coordinate style
+  // indexing to global, scalar indexing
+  // example: for nth (2,1,4) : (1,0,0)->1, (1,1,0)->4
+
+  // Global (scalar) indexing to local index-system
   auto local_ids_ = [&nth_derivs](const std::size_t req_id)
       -> std::array<std::size_t, parametric_dimension> {
     std::size_t id{req_id};
@@ -212,7 +215,8 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
     }
     return local_ids;
   };
-  // From array of indices to single index
+
+  // Local (coordinate-style) indexing to global
   auto global_ids_ =
       [&nth_derivs](
           const std::array<std::size_t, parametric_dimension>& req_derivs)
@@ -227,6 +231,7 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
     }
     return id;
   };
+
   // Check if requested derivative is "subset" to current derivative
   auto is_not_subset_ =
       [](const std::array<std::size_t, parametric_dimension>& req_derivs_max,

--- a/src/rational_bezier_spline.inc
+++ b/src/rational_bezier_spline.inc
@@ -193,6 +193,91 @@ constexpr PhysicalPointType RationalBezierSpline<
 
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
+constexpr PhysicalPointType
+RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
+    EvaluateDerivative(
+        const PointTypeParametric_& par_coords,
+        const std::array<std::size_t, parametric_dimension>& nth_derivs) const {
+  // Define Lambdas for indexing
+  // From a single index notation to an array of indices
+  auto local_ids_ = [&nth_derivs](const std::size_t req_id)
+      -> std::array<std::size_t, parametric_dimension> {
+    std::size_t id{req_id};
+    std::array<std::size_t, parametric_dimension> local_ids{};
+    for (std::size_t i_pd{}; i_pd < parametric_dimension; i_pd++) {
+      if (nth_derivs[i_pd] == 0) continue;
+      local_ids[i_pd] = id % (nth_derivs[i_pd] + 1);
+      id -= local_ids[i_pd];
+      id /= nth_derivs[i_pd] + 1;
+    }
+    return local_ids;
+  };
+  // From array of indices to single index
+  auto global_ids_ =
+      [&nth_derivs](
+          const std::array<std::size_t, parametric_dimension>& req_derivs)
+      -> std::size_t {
+    std::size_t id{};
+    std::size_t offset{1};
+    for (std::size_t i_pd{}; i_pd < parametric_dimension; i_pd++) {
+      // assert(req_derivs[i_pd] <= nth_derivs[i_pd]);
+      if (nth_derivs[i_pd] == 0) continue;
+      id += offset * (req_derivs[i_pd]);
+      offset = nth_derivs[i_pd] > 0 ? offset * (nth_derivs[i_pd] + 1) : offset;
+    }
+    return id;
+  };
+
+  // Initialize return type
+  const std::size_t number_of_derivs{global_ids_(nth_derivs) + 1};
+  // Please remember that the first derivative is not used
+  std::vector<PhysicalPointType> derivatives(number_of_derivs);
+  std::vector<PhysicalPointType> A_derivatives(number_of_derivs);
+  std::vector<ScalarType> w_derivatives(number_of_derivs);
+
+  // Fill all polynomial spline derivatives (and values for id=0)
+  for (std::size_t i_deriv{}; i_deriv < number_of_derivs; i_deriv++) {
+    const auto req_derivs = local_ids_(i_deriv);
+    A_derivatives[i_deriv] =
+        weighted_spline_.EvaluateDerivative(par_coords, req_derivs);
+    w_derivatives[i_deriv] =
+        weight_function_.EvaluateDerivative(par_coords, req_derivs);
+  }
+
+  // Precompute inverse of weighted function
+  const ScalarType inv_w_fact = static_cast<ScalarType>(1.) / w_derivatives[0];
+
+  // Loop over all lower-order derivatives and assign derivatives-vector
+  // Notation follows "The NURBS book" eq. 4.20 (extended for n-d splines)
+  for (std::size_t i_deriv{0}; i_deriv < number_of_derivs; i_deriv++) {
+    // Retrieve index-wise order of the derivative for current ID
+    const auto derivative_order_indexwise_LHS = local_ids_(i_deriv);
+    // Assign derivative of Numerator-function
+    derivatives[i_deriv] = A_derivatives[i_deriv];
+    // Substract all weighted lower-order functions
+    for (std::size_t j_deriv{0}; j_deriv < i_deriv; j_deriv++) {
+      // Retrieve order of current index
+      const auto derivative_order_indexwise_RHS = local_ids_(j_deriv);
+      // Precompute Product of binomial coefficients
+      std::size_t binom_fact{1};
+      for (std::size_t i_pd{}; i_pd < parametric_dimension; i_pd++) {
+        binom_fact *= utils::FastBinomialCoefficient::choose(
+            derivative_order_indexwise_LHS[i_pd],
+            derivative_order_indexwise_RHS[i_pd]);
+      }
+      // Substract low-order function
+      derivatives[i_deriv] -=
+          binom_fact * w_derivatives[i_deriv - j_deriv] * derivatives[j_deriv];
+    }
+    // Finalize
+    derivatives[i_deriv] *= inv_w_fact;
+  }
+  // Return last value
+  return derivatives[number_of_derivs - 1];
+}
+
+template <std::size_t parametric_dimension, typename PhysicalPointType,
+          typename ScalarType>
 constexpr RationalBezierSpline<parametric_dimension, PhysicalPointType,
                                ScalarType>&
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::

--- a/src/rational_bezier_spline.inc
+++ b/src/rational_bezier_spline.inc
@@ -227,6 +227,16 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
     }
     return id;
   };
+  // Check if requested derivative is "subset" to current derivative
+  auto is_not_subset_ =
+      [](const std::array<std::size_t, parametric_dimension>& req_derivs_max,
+         const std::array<std::size_t, parametric_dimension>& req_derivs)
+      -> bool {
+    for (std::size_t i_pd{}; i_pd < parametric_dimension; i_pd++) {
+      if (req_derivs[i_pd] > req_derivs_max[i_pd]) return true;
+    }
+    return false;
+  };
 
   // Initialize return type
   const std::size_t number_of_derivs{global_ids_(nth_derivs) + 1};
@@ -255,9 +265,13 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
     // Assign derivative of Numerator-function
     derivatives[i_deriv] = A_derivatives[i_deriv];
     // Substract all weighted lower-order functions
-    for (std::size_t j_deriv{0}; j_deriv < i_deriv; j_deriv++) {
+    for (std::size_t j_deriv{1}; j_deriv <= i_deriv; j_deriv++) {
       // Retrieve order of current index
       const auto derivative_order_indexwise_RHS = local_ids_(j_deriv);
+      // Check only subsets
+      if (is_not_subset_(derivative_order_indexwise_LHS,
+                         derivative_order_indexwise_RHS))
+        continue;
       // Precompute Product of binomial coefficients
       std::size_t binom_fact{1};
       for (std::size_t i_pd{}; i_pd < parametric_dimension; i_pd++) {
@@ -267,7 +281,7 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
       }
       // Substract low-order function
       derivatives[i_deriv] -=
-          binom_fact * w_derivatives[i_deriv - j_deriv] * derivatives[j_deriv];
+          binom_fact * w_derivatives[j_deriv] * derivatives[i_deriv - j_deriv];
     }
     // Finalize
     derivatives[i_deriv] *= inv_w_fact;

--- a/src/utils/algorithms/CMakeLists.txt
+++ b/src/utils/algorithms/CMakeLists.txt
@@ -1,9 +1,10 @@
 # Add Files
 set(LOCAL_HEADERS 
+  ${CMAKE_CURRENT_SOURCE_DIR}/bernstein_polynomial.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/hypercube.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/int_power.hpp
-  ${CMAKE_CURRENT_SOURCE_DIR}/sort.hpp
   ${CMAKE_CURRENT_SOURCE_DIR}/point_uniquifier.hpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/sort.hpp
 )
 
 # Add All Subdirectories

--- a/src/utils/algorithms/bernstein_polynomial.hpp
+++ b/src/utils/algorithms/bernstein_polynomial.hpp
@@ -1,0 +1,115 @@
+#ifndef UTILS_ALGORITHMS_BERNSTEIN_POLYNOMIAL_HPP
+#define UTILS_ALGORITHMS_BERNSTEIN_POLYNOMIAL_HPP
+
+#include <cassert>
+#include <vector>
+
+#include "bezman/src/utils/fastbinomialcoefficient.hpp"
+
+namespace bezman::utils::algorithms {
+/**
+ * @brief
+ *
+ * @tparam ScalarType
+ */
+template <typename ScalarType = double>
+class BernsteinPolynomial {
+ public:
+  /**
+   * @brief Evaluate Bernstein polynomials
+   *
+   * Efficient calculations of Bernstein polynomials to avoid power expressions
+   *
+   * @param value   position to be evaluated
+   * @param degree  polynomial degrees
+   * @return constexpr std::vector<ScalarType> vector of evaluations of the
+   * different basis functions
+   */
+  static inline constexpr std::vector<ScalarType> Evaluate(
+      const std::size_t& degree, const ScalarType& value) {
+    // Check if degree is available
+    assert(degree < MAX_BINOMIAL_DEGREE);
+
+    // Init Return Type
+    std::vector<ScalarType> evaluations;
+
+    // Preallocate space to vectors
+    evaluations.reserve(degree + 1);
+
+    // Loop over parametric dimensions to precalculate basisfunctions
+    ScalarType cfactor = static_cast<ScalarType>(1.);
+    const ScalarType inv_value = cfactor - value;
+
+    // Loop over dimensionwise ctps
+    for (std::size_t i_basis{0}; i_basis < degree + 1; i_basis++) {
+      evaluations.push_back(
+          static_cast<ScalarType>(
+              utils::FastBinomialCoefficient::choose(degree, i_basis)) *
+          cfactor);
+      cfactor *= value;
+    }
+    // Backwards assignment
+    cfactor = static_cast<ScalarType>(1.);
+    for (std::size_t i_basis{0}; i_basis < degree + 1; i_basis++) {
+      evaluations[degree - i_basis] *= cfactor;
+      cfactor *= inv_value;
+    }
+    return evaluations;
+  }
+
+  /**
+   * @brief
+   *
+   * @param value
+   * @param degree
+   * @param deriv
+   * @return constexpr std::vector<ScalarType>
+   */
+  static inline constexpr std::vector<ScalarType> EvaluateDerivative(
+      const std::size_t& degree, const ScalarType& value,
+      const std::size_t& deriv) {
+    // Check if degree is available
+    assert(degree < MAX_BINOMIAL_DEGREE);
+
+    // Init Return Type
+    std::vector<ScalarType> evaluations;
+
+    // Determine derivatives
+    if (degree < deriv) {
+      evaluations.resize(degree + 1);
+      return evaluations;
+    } else if (deriv == 0) {
+      return Evaluate(degree, value);
+    } else {
+      // based on doi:10.1155/2011/829543, section 3
+      // Retrive low order basis functions
+      const std::vector<ScalarType> basis = Evaluate(degree - deriv, value);
+      // Auxiliary value
+      const ScalarType aux_factor = [&degree, &deriv]() {
+        ScalarType value{1};
+        for (std::size_t i_deg{degree}; i_deg > (degree - deriv); i_deg--) {
+          value *= i_deg;
+        }
+        return value;
+      }();
+      // Start actual calculation using the papers notation
+      evaluations.resize(degree + 1);
+      for (std::size_t i_basis{0}; i_basis < degree + 1; i_basis++) {
+        const std::size_t k_min{static_cast<std::size_t>(
+            std::max(0, static_cast<int>(i_basis + deriv - degree)))};
+        for (std::size_t k{k_min}; k <= std::min(i_basis, deriv); k++) {
+          // Check if is even using binary operation
+          const ScalarType eval_v =
+              utils::FastBinomialCoefficient::choose(deriv, k) *
+              basis[i_basis - k];
+          evaluations[i_basis] += ((k + deriv) & 1) ? -eval_v : eval_v;
+        }
+        evaluations[i_basis] *= aux_factor;
+      }
+      return evaluations;
+    }
+  }
+};
+}  // namespace bezman::utils::algorithms
+
+#endif  // UTILS_ALGORITHMS_BERNSTEIN_POLYNOMIAL_HPP

--- a/src/utils/algorithms/bernstein_polynomial.hpp
+++ b/src/utils/algorithms/bernstein_polynomial.hpp
@@ -1,3 +1,27 @@
+/*
+MIT License
+
+Copyright (c) 2022 zwar@ilsb.tuwien.ac.at
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
 #ifndef UTILS_ALGORITHMS_BERNSTEIN_POLYNOMIAL_HPP
 #define UTILS_ALGORITHMS_BERNSTEIN_POLYNOMIAL_HPP
 

--- a/src/utils/fastbinomialcoefficient.hpp
+++ b/src/utils/fastbinomialcoefficient.hpp
@@ -26,6 +26,7 @@ SOFTWARE.
 #define SRC_UTILS_FASTBINOMIALCOEFFICIENT_HPP
 
 #include <array>
+#include <cassert>
 
 #include "bezman/src/utils/binomialcoefficientlookuptablecreator.hpp"
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(algo_diff_type)
 add_subdirectory(basic_operations)
+add_subdirectory(bernstein_polynomials)
 add_subdirectory(bezier_group)
 add_subdirectory(composition)
 add_subdirectory(composition_group)

--- a/tests/bernstein_polynomials/CMakeLists.txt
+++ b/tests/bernstein_polynomials/CMakeLists.txt
@@ -1,0 +1,16 @@
+set(
+    TEST_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/bernstein_polynomial_test.cpp
+)
+
+# Search for the library
+add_executable(bernstein_polynomial_test ${TEST_SOURCES})
+
+# Link bezier manipulation library to the executable target
+add_dependencies(bernstein_polynomial_test ${MY_FANCY_TARGET_NAME})
+target_link_libraries(bernstein_polynomial_test
+                  PRIVATE ${MY_FANCY_TARGET_NAME}
+                  PRIVATE gtest_main)
+
+include(GoogleTest)
+add_test(NAME bernstein_polynomial_test COMMAND bernstein_polynomial_test)

--- a/tests/bernstein_polynomials/bernstein_polynomial_test.cpp
+++ b/tests/bernstein_polynomials/bernstein_polynomial_test.cpp
@@ -1,0 +1,123 @@
+/*
+MIT License
+
+Copyright (c) 2022 zwar@ilsb.tuwien.ac.at
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "bezman/src/utils/algorithms/bernstein_polynomial.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdlib>
+#include <vector>
+
+using namespace bezman;
+
+namespace bezman::tests::bernstein_polynomial_test {
+
+class BernsteinPolynomialTest : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+
+  const double PI = std::acos(-1);
+
+  // Analytical implementation of some polynomials
+  double b02(const double& x) { return 1 - 2 * x + x * x; }
+  double b12(const double& x) { return 2 * x - 2 * x * x; }
+  double b22(const double& x) { return x * x; }
+  double b02_1(const double& x) { return -2. + 2. * x; }
+  double b12_1(const double& x) { return 2. - 4. * x; }
+  double b22_1(const double& x) { return 2. * x; }
+  double b02_2([[maybe_unused]] const double& x) { return 2.; }
+  double b12_2([[maybe_unused]] const double& x) { return -4.; }
+  double b22_2([[maybe_unused]] const double& x) { return 2.; }
+
+  // Envelop function (see )
+  double BernsteinEnvelope(const std::size_t& degree, const double& value) {
+    return 1. / std::sqrt(2 * PI * degree * value * (1 - value));
+  }
+};
+
+TEST_F(BernsteinPolynomialTest, TestEnvelopAndPartitionOfUnity) {
+  std::size_t n_tests = 10;
+  for (std::size_t i_test{}; i_test < n_tests; i_test++) {
+    const std::size_t degree = rand() % 30;
+    const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+    const auto evaluations =
+        bezman::utils::algorithms::BernsteinPolynomial<double>::Evaluate(degree,
+                                                                         x);
+    double sum{};
+    const double env_v = BernsteinEnvelope(degree, x);
+    for (std::size_t i_basis{}; i_basis < degree + 1; i_basis++) {
+      sum += evaluations[i_basis];
+      EXPECT_TRUE(evaluations[i_basis] <= env_v);
+    }
+    EXPECT_FLOAT_EQ(sum, 1.);
+  }
+}
+
+TEST_F(BernsteinPolynomialTest, TestDerivatives) {
+  std::size_t n_tests = 10;
+  std::size_t max_degree = 8;
+  // Test that derivatives sum up to 0
+  for (std::size_t i_test{}; i_test < n_tests; i_test++) {
+    const std::size_t degree = rand() % max_degree + 2;
+    // Make sure deriv is at least 1 but <= degree
+    const std::size_t deriv = rand() % (degree - 1) + 1;
+    const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+    const auto deriv_evaluations =
+        bezman::utils::algorithms::BernsteinPolynomial<
+            double>::EvaluateDerivative(degree, x, deriv);
+    double sum{};
+    for (std::size_t i_basis{}; i_basis < (degree + 1); i_basis++) {
+      sum += deriv_evaluations[i_basis];
+    }
+    // The sum should be zero, however, the values are extremely high for high
+    // derivatives, so it should be scaled (order of magnitude is n!/(n-p!),)
+    EXPECT_TRUE(sum < 1e-10);
+  }
+
+  // Test explicitely for second degree polynomial
+  for (std::size_t i_test{}; i_test < n_tests; i_test++) {
+    // Make sure deriv is at least 1 but <= degree
+    const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+    const auto evaluations = bezman::utils::algorithms::BernsteinPolynomial<
+        double>::EvaluateDerivative(2, x, 0);
+    const auto deriv_evaluations =
+        bezman::utils::algorithms::BernsteinPolynomial<
+            double>::EvaluateDerivative(2, x, 1);
+    const auto sec_deriv_evaluations =
+        bezman::utils::algorithms::BernsteinPolynomial<
+            double>::EvaluateDerivative(2, x, 2);
+    EXPECT_FLOAT_EQ(evaluations[0], b02(x));
+    EXPECT_FLOAT_EQ(evaluations[1], b12(x));
+    EXPECT_FLOAT_EQ(evaluations[2], b22(x));
+    EXPECT_FLOAT_EQ(deriv_evaluations[0], b02_1(x));
+    EXPECT_FLOAT_EQ(deriv_evaluations[1], b12_1(x));
+    EXPECT_FLOAT_EQ(deriv_evaluations[2], b22_1(x));
+    EXPECT_FLOAT_EQ(sec_deriv_evaluations[0], b02_2(x));
+    EXPECT_FLOAT_EQ(sec_deriv_evaluations[1], b12_2(x));
+    EXPECT_FLOAT_EQ(sec_deriv_evaluations[2], b22_2(x));
+  }
+}
+
+}  // namespace bezman::tests::bernstein_polynomial_test

--- a/tests/bezier_group/bezier_group_test.cpp
+++ b/tests/bezier_group/bezier_group_test.cpp
@@ -27,9 +27,9 @@ SOFTWARE.
 #include <gtest/gtest.h>
 
 #include <array>
-#include <bezman/src/rational_bezier_spline.hpp>
 
 #include "bezman/src/bezier_spline.hpp"
+#include "bezman/src/rational_bezier_spline.hpp"
 
 using namespace bezman;
 

--- a/tests/composition/composition_test.cpp
+++ b/tests/composition/composition_test.cpp
@@ -92,8 +92,9 @@ TEST_F(BezierTestingSuite, CompositionHighOrder) {
   }
   const auto composed_spline = surface.Compose(line);
 
-  std::cerr << "[          ] surface-degrees: =     \t(" << surface.GetDegrees()[0]
-            << ", " << surface.GetDegrees()[1] << ")" << std::endl;
+  std::cerr << "[          ] surface-degrees: =     \t("
+            << surface.GetDegrees()[0] << ", " << surface.GetDegrees()[1] << ")"
+            << std::endl;
   std::cerr << "[          ] line-degree: =         \t(" << line.GetDegrees()[0]
             << ")" << std::endl;
 

--- a/tests/io/base64/base64_test.cpp
+++ b/tests/io/base64/base64_test.cpp
@@ -66,8 +66,8 @@ TEST_F(Base64ExportSuite, ExportImportTest) {
 
 TEST_F(Base64ExportSuite, ExportImportTestPoints) {
   // Points
-  const auto test_point_ctps = Base64::Decode<bezman::Point<3ul, double>>(
-      Base64::Encode(point_vector));
+  const auto test_point_ctps =
+      Base64::Decode<bezman::Point<3ul, double>>(Base64::Encode(point_vector));
   EXPECT_EQ(point_vector, test_point_ctps);
 }
 

--- a/tests/rational_splines/rational_splines_test.cpp
+++ b/tests/rational_splines/rational_splines_test.cpp
@@ -309,38 +309,39 @@ TEST_F(RationalSplineTestSuite, DerivativeTesting) {
 
 // Test Derivatives of rational Beziers
 TEST_F(RationalSplineTestSuite, DerivativeEvaluation) {
-  auto rand_int = [](const std::size_t& min, const std::size_t& max) {
-    std::size_t interval = max - min;
-    return min + rand() % interval;
-  };
-  const auto degrees = std::array<std::size_t, 3>{
-      rand_int(3, 6), rand_int(3, 6), rand_int(3, 6)};
-  const auto derivs = std::array<std::size_t, 3>{rand_int(0, 3), rand_int(0, 3),
-                                                 rand_int(0, 3)};
-  const auto random_spline = CreateRandomSpline(degrees);
-  auto random_spline_deriv = random_spline;
-  for (std::size_t i_para_dim{}; i_para_dim < 3; i_para_dim++) {
-    for (std::size_t i_deriv{}; i_deriv < derivs[i_para_dim]; i_deriv++) {
-      random_spline_deriv =
-          random_spline_deriv.DerivativeWRTParametricDimension(i_para_dim);
-    }
-  }
-  const std::size_t n_tests = 10;
+  constexpr std::size_t n_tests{3}, para_dims{2};
+  const std::size_t n_test_evaluations{5};
   for (std::size_t i_test{}; i_test < n_tests; i_test++) {
-    // Create evaluation points
-    const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
-    const double y{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
-    const double z{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
-    Point3D eval_point{x, y, z};
-    const auto result = random_spline.EvaluateDerivative(
-        // Evaluation Point
-        eval_point,
-        // derivatives
-        derivs);
-    const auto result_2 = random_spline_deriv.Evaluate(eval_point);
-    // Compare results dimensions
-    for (std::size_t i_dim{}; i_dim < 3; i_dim++) {
-      EXPECT_FLOAT_EQ(result[i_dim], result_2[i_dim]);
+    const auto degrees = std::array<std::size_t, para_dims>{3, 3};
+    const auto derivs = std::array<std::array<std::size_t, para_dims>, n_tests>{
+        2, 0, 1, 1, 1, 2}[i_test];
+    const auto random_spline = CreateRandomSpline(degrees);
+    auto random_spline_deriv = random_spline;
+    for (std::size_t i_para_dim{}; i_para_dim < para_dims; i_para_dim++) {
+      for (std::size_t i_deriv{}; i_deriv < derivs[i_para_dim]; i_deriv++) {
+        random_spline_deriv =
+            random_spline_deriv.DerivativeWRTParametricDimension(i_para_dim);
+      }
+    }
+
+    // Evaluate for comparison
+    for (std::size_t i_test{}; i_test < n_test_evaluations; i_test++) {
+      // Create evaluation points
+      const double x{static_cast<double>(rand()) /
+                     static_cast<double>(RAND_MAX)};
+      const double y{static_cast<double>(rand()) /
+                     static_cast<double>(RAND_MAX)};
+      Point2D eval_point{x, y};
+      const auto result = random_spline.EvaluateDerivative(
+          // Evaluation Point
+          eval_point,
+          // derivatives
+          derivs);
+      const auto result_2 = random_spline_deriv.Evaluate(eval_point);
+      // Compare results dimensions
+      for (std::size_t i_dim{}; i_dim < 3; i_dim++) {
+        EXPECT_FLOAT_EQ(result[i_dim], result_2[i_dim]);
+      }
     }
   }
 }


### PR DESCRIPTION
# Addressed issues
- #4 

# Description
Evaluate derivatives directly at a certain point without the need to build the derivative spline first. Similar to what SplineLib is doing.

## New Feature Showcase 
```
// Requested derivatives
const std::array<std::size_t, 3> derivatives{1,0,1};
// Given a 3D->3D spline of degrees [3,2,4]
PointType derivative = spline.EvaluateDerivative(evaluation_point, derivatives);
// Which is equivalent to
PointType derivative = spline
    .DerivativeWRTParametricDimension(0)
    .DerivativeWRTParametricDimension(2)
    .Evaluate(evaluation_point);
```

# Check list
### Test documentation
* [x]  Build Debug
* [x]  Build Release Mode
* [x]  Executed Tests
* [x]  Build Tests
* [x]  Executed Examples
* [x] Added a new unit-test for feature

### Documentation of changes and theory
* [x]  I have updated the relevant documentations, as far as necessary.

### Style guide compliance
* [x]  Edited `C++` files formatted with clang-format (`10.x.x`+)

