### PR TITLE
Split Up Connectivity function into two seperate functions

### DIFF
--- a/src/bezier_group.hpp
+++ b/src/bezier_group.hpp
@@ -101,7 +101,7 @@ class BezierGroup : public std::vector<SplineType> {
 
   /// Initializer list overload
   template <typename... Splines>
-  constexpr BezierGroup(const Splines &... splines)
+  constexpr BezierGroup(const Splines &...splines)
       : BaseVector{static_cast<SplineType>(splines)...} {}
 
   /// Check if group fits unit cube


### PR DESCRIPTION
# Split up connectivity function
The connectivity function recently worked with corner vertices, but now there are two seperate functions that also provide functionality for center points. That might be useful for splinepy, as one can directly work on center-evaluations.

# Check list
### Test documentation (delete if not applicable)
* [x]  Build Debug
* [x]  Build Release Mode
* [x]  Executed Tests
* [x]  Build Tests
* [x]  Executed Examples

### Documentation of changes and theory
* [x]  I have updated the relevant documentations, as far as necessary.

### Style guide compliance
* [x]  Edited `C++` files formatted with clang-format (`10.x.x`+)

