### PR TITLE
Ft higher order derivatives

### DIFF
--- a/.github/workflows/check_format.yml
+++ b/.github/workflows/check_format.yml
@@ -18,4 +18,4 @@ jobs:
         run: sudo apt-get install -y clang-format
 
       - name: Format
-        run: find src -iname *.hpp -o -iname *inc | xargs clang-format --dry-run --style=Google -Werror
+        run: find src tests -iname *.hpp -o -iname *inc -o -iname *.cpp | xargs clang-format --dry-run --style=Google -Werror

--- a/src/bezier_spline.hpp
+++ b/src/bezier_spline.hpp
@@ -134,6 +134,7 @@ class BezierSpline {
   };
   /// Make ScalarType publicly available
   using ScalarType_ = ScalarType;
+  using IndexingType_ = IndexingType;
   using PhysicalPointType_ = PhysicalPointType;
 
   /// Offsets in Row based control point storage
@@ -157,7 +158,7 @@ class BezierSpline {
    *
    * @param global_idex Array index type as std::array
    */
-  constexpr IndexingType GlobaToLocalIndex(
+  constexpr IndexingType GlobalToLocalIndex(
       const std::array<IndexingType, parametric_dimension>& global_index) const;
 
   /*

--- a/src/bezier_spline.hpp
+++ b/src/bezier_spline.hpp
@@ -145,12 +145,20 @@ class BezierSpline {
   static constexpr IndexingType kParametricDimensions = parametric_dimension;
 
   /*
-   * Retrieve individual indices
+   * Retrieve multidimensional indices
    *
    * @param local_indices single value index as control point index
    */
   constexpr std::array<IndexingType, parametric_dimension> LocalToGlobalIndex(
       const IndexingType& local_index) const;
+
+  /*
+   * Retrieve global scalar index
+   *
+   * @param global_idex Array index type as std::array
+   */
+  constexpr IndexingType GlobaToLocalIndex(
+      const std::array<IndexingType, parametric_dimension>& global_index) const;
 
   /*
    * Calculate the new control point that result from the multiplication
@@ -257,7 +265,7 @@ class BezierSpline {
 
   /// Derivative along a specific parametric dimension
   constexpr BezierSpline DerivativeWRTParametricDimension(
-      const IndexingType par_dim) const;
+      const std::array<IndexingType, parametric_dimension>& orders) const;
 
   /// Evaluate the spline using the de Casteljau algorithm
   template <typename... T>

--- a/src/bezier_spline.hpp
+++ b/src/bezier_spline.hpp
@@ -83,7 +83,7 @@ class BezierSpline {
    * Check out their respective documentation for more information
    */
   template <bool compute_sensitivities, typename SplineType>
-  constexpr auto ComposeNumeratorHelper(const SplineType& inner_function) const;
+  constexpr auto ComposeNumeratorHelper(const SplineType &inner_function) const;
 
   /**
    * @brief Compose the Numerator Function of a polynomial and rational spline
@@ -93,7 +93,7 @@ class BezierSpline {
    */
   template <typename SplineType>
   constexpr auto ComposeNumeratorSpline(
-      const SplineType& inner_function) const {
+      const SplineType &inner_function) const {
     return ComposeNumeratorHelper<false>(inner_function);
   }
 
@@ -107,7 +107,7 @@ class BezierSpline {
    */
   template <typename SplineType>
   constexpr auto ComposeNumeratorSensitivity(
-      const SplineType& inner_function) const {
+      const SplineType &inner_function) const {
     return ComposeNumeratorHelper<true>(inner_function);
   }
 
@@ -124,12 +124,12 @@ class BezierSpline {
                          decltype(ScalarType{} * ScalarRHS{})>
   ComposeDenominatorSpline(
       const RationalBezierSpline<parametric_dimension_inner_spline,
-                                 PointTypeRHS, ScalarRHS>& inner_function)
+                                 PointTypeRHS, ScalarRHS> &inner_function)
       const;
 
  public:
   /// Make Number Of Control Points available
-  const IndexingType& GetNumberOfControlPoints() const {
+  const IndexingType &GetNumberOfControlPoints() const {
     return number_of_control_points;
   };
   /// Make ScalarType publicly available
@@ -151,7 +151,7 @@ class BezierSpline {
    * @param local_indices single value index as control point index
    */
   constexpr std::array<IndexingType, parametric_dimension> LocalToGlobalIndex(
-      const IndexingType& local_index) const;
+      const IndexingType &local_index) const;
 
   /*
    * Retrieve global scalar index
@@ -159,7 +159,7 @@ class BezierSpline {
    * @param global_idex Array index type as std::array
    */
   constexpr IndexingType GlobalToLocalIndex(
-      const std::array<IndexingType, parametric_dimension>& global_index) const;
+      const std::array<IndexingType, parametric_dimension> &global_index) const;
 
   /*
    * Calculate the new control point that result from the multiplication
@@ -169,15 +169,15 @@ class BezierSpline {
   template <typename PhysicalPointLHS, typename ScalarLHS,
             typename PhysicalPointRHS, typename ScalarRHS, typename... T>
   constexpr void CombineControlPointsForProduct_(
-      const BezierSpline<parametric_dimension, PhysicalPointLHS, ScalarLHS>&
-          P_spline,
-      const BezierSpline<parametric_dimension, PhysicalPointRHS, ScalarRHS>&
-          Q_spline,
-      const std::array<IndexingType, parametric_dimension>& ctpsIndex,
-      const ScalarType factor, const T&... indices);
+      const BezierSpline<parametric_dimension, PhysicalPointLHS, ScalarLHS>
+          &P_spline,
+      const BezierSpline<parametric_dimension, PhysicalPointRHS, ScalarRHS>
+          &Q_spline,
+      const std::array<IndexingType, parametric_dimension> &ctpsIndex,
+      const ScalarType factor, const T &...indices);
 
   /// Copy constructor
-  constexpr BezierSpline(const BezierSpline& bezier_spline) = default;
+  constexpr BezierSpline(const BezierSpline &bezier_spline) = default;
 
   /// Empty constructor
   constexpr BezierSpline() = default;
@@ -195,8 +195,8 @@ class BezierSpline {
 
   /// Constructor with control point list
   constexpr BezierSpline(
-      const std::array<std::size_t, parametric_dimension>& deg,
-      const std::vector<PhysicalPointType>& points)
+      const std::array<std::size_t, parametric_dimension> &deg,
+      const std::vector<PhysicalPointType> &points)
       : degrees{deg}, control_points{points} {
     number_of_control_points = 1u;
     for (unsigned int i{}; i < parametric_dimension; i++)
@@ -207,13 +207,13 @@ class BezierSpline {
   };
 
   /// Move operator
-  constexpr BezierSpline& operator=(BezierSpline&& rhs) = default;
+  constexpr BezierSpline &operator=(BezierSpline &&rhs) = default;
 
   /// Move operator
-  constexpr BezierSpline& operator=(const BezierSpline& rhs) = default;
+  constexpr BezierSpline &operator=(const BezierSpline &rhs) = default;
 
   /// Getter for Degrees
-  constexpr const std::array<std::size_t, parametric_dimension>& GetDegrees()
+  constexpr const std::array<std::size_t, parametric_dimension> &GetDegrees()
       const {
     return degrees;
   }
@@ -225,7 +225,7 @@ class BezierSpline {
 
   /// Set Degrees
   constexpr void UpdateDegrees(
-      const std::array<std::size_t, parametric_dimension>& new_degrees) {
+      const std::array<std::size_t, parametric_dimension> &new_degrees) {
     degrees = new_degrees;
     number_of_control_points = 1u;
     for (unsigned int i{}; i < parametric_dimension; i++)
@@ -235,96 +235,114 @@ class BezierSpline {
   }
 
   /// Access Control Point Vector directly (for conformity to rationals)
-  constexpr const std::vector<PhysicalPointType>& GetControlPoints() const {
+  constexpr const std::vector<PhysicalPointType> &GetControlPoints() const {
     return control_points;
   }
 
   /// Access Control Point Vector directly (for conformity to rationals)
-  constexpr std::vector<PhysicalPointType>& GetControlPoints() {
+  constexpr std::vector<PhysicalPointType> &GetControlPoints() {
     return control_points;
   }
 
   /// Retrieve single control point from local indices
   template <typename... T>
-  constexpr const PhysicalPointType_& ControlPoint(const T... index) const;
+  constexpr const PhysicalPointType_ &ControlPoint(const T... index) const;
 
   /// Retrieve single control point from local indices
   template <typename... T>
-  constexpr PhysicalPointType_& ControlPoint(const T... index);
+  constexpr PhysicalPointType_ &ControlPoint(const T... index);
 
   /// Retrieve single control point from local indices (as array)
-  constexpr const PhysicalPointType_& ControlPoint(
-      const std::array<IndexingType, parametric_dimension>& index) const;
+  constexpr const PhysicalPointType_ &ControlPoint(
+      const std::array<IndexingType, parametric_dimension> &index) const;
 
   /// Retrieve single control point from local indices (as array)
-  constexpr PhysicalPointType_& ControlPoint(
-      const std::array<IndexingType, parametric_dimension>& index);
+  constexpr PhysicalPointType_ &ControlPoint(
+      const std::array<IndexingType, parametric_dimension> &index);
 
   /// Order elevation along a specific parametric dimension
-  constexpr BezierSpline& OrderElevateAlongParametricDimension(
+  constexpr BezierSpline &OrderElevateAlongParametricDimension(
       const IndexingType par_dim);
 
-  /// Derivative along a specific parametric dimension
+  /**
+   * Determine the close form representation of the derivative
+   *
+   * The orders are set per parameteric dimension, meaning that {1, 2} will
+   * result in the first order derivative along the first parametric axis
+   * and the second order derivative alon the second parametric axis.
+   *
+   * The control points are computed as follows
+   * \f[
+   * \hat{C}_i^k=\frac{p!}{(p-k)!}\sum_{j=0}^k (-1)^{j+1}\binom{k}{j}C_{i+j}
+   * \f]
+   * where \f$\hat{C}_i^k\f$ denotes the control point of the close form of
+   * spline the derivative, \f$ p \f$ is the degree of the original spline,
+   * \f$k\f$ is the order of the derivative (in a given parametric direction)
+   * \f$C_i\f$ are the original control points
+   *
+   * @param orders array denoting the orders along the respective parametric
+   * axis
+   */
   constexpr BezierSpline DerivativeWRTParametricDimension(
-      const std::array<IndexingType, parametric_dimension>& orders) const;
+      const std::array<IndexingType, parametric_dimension> &orders) const;
 
   /// Evaluate the spline using the de Casteljau algorithm
   template <typename... T>
-  constexpr PhysicalPointType_ Evaluate(const T&... par_coords) const {
+  constexpr PhysicalPointType_ Evaluate(const T &...par_coords) const {
     return Evaluate(PointTypeParametric_{par_coords...});
   }
 
   /// Evaluate the spline via the deCasteljau algorithm
   constexpr PhysicalPointType_ Evaluate(
-      const PointTypeParametric_& par_coords) const;
+      const PointTypeParametric_ &par_coords) const;
 
   /// Evaluate Basis Functions
   template <typename... T>
   constexpr std::array<std::vector<ScalarType>, parametric_dimension>
-  BasisFunctionContributions(const T&... par_coords) const {
+  BasisFunctionContributions(const T &...par_coords) const {
     return BasisFunctionContributions(PointTypeParametric_{par_coords...});
   }
 
   /// Evaluate Basis Functions
   constexpr std::array<std::vector<ScalarType>, parametric_dimension>
-  BasisFunctionContributions(const PointTypeParametric_& par_coords) const;
+  BasisFunctionContributions(const PointTypeParametric_ &par_coords) const;
 
   /// Evaluate Basis Functions Unraveled using Cartesian Product of p-dim
   constexpr std::vector<ScalarType> BasisFunctions(
-      const PointTypeParametric_& par_coords) const;
+      const PointTypeParametric_ &par_coords) const;
 
   /// Evaluate Basis Functions Unraveled using Cartesian Product of p-dim
   template <typename... T>
   constexpr std::vector<ScalarType> BasisFunctions(
-      const T&... par_coords) const {
+      const T &...par_coords) const {
     return BasisFunctions(PointTypeParametric_{par_coords...});
   }
 
   /// Evaluate Basis Functions Derivatives
   constexpr std::vector<ScalarType> BasisFunctionsDerivatives(
-      const PointTypeParametric_& par_coords,
-      const std::array<std::size_t, parametric_dimension>& nth_derivs) const;
+      const PointTypeParametric_ &par_coords,
+      const std::array<std::size_t, parametric_dimension> &nth_derivs) const;
 
   /// Evaluate Basis Functions Derivatives
   constexpr std::array<std::vector<ScalarType>, parametric_dimension>
   BasisFunctionsDerivativeContributions(
-      const PointTypeParametric_& par_coords,
-      const std::array<std::size_t, parametric_dimension>& nth_derivs) const;
+      const PointTypeParametric_ &par_coords,
+      const std::array<std::size_t, parametric_dimension> &nth_derivs) const;
 
   /// Evaluate the spline via the explicit precomputation of bernstein
   /// values
   constexpr PhysicalPointType_ ForwardEvaluate(
-      const PointTypeParametric_& par_coords) const;
+      const PointTypeParametric_ &par_coords) const;
 
   /// Evaluate the derivatives of a spline via the explicit precomputation of
   /// bernstein polynomial derivativs
   constexpr PhysicalPointType_ EvaluateDerivative(
-      const PointTypeParametric_& par_coords,
-      const std::array<std::size_t, parametric_dimension>& nth_derivs) const;
+      const PointTypeParametric_ &par_coords,
+      const std::array<std::size_t, parametric_dimension> &nth_derivs) const;
 
   /// Evaluate the spline using explicit precomputation of bernstein values
   template <typename... T>
-  constexpr PhysicalPointType_ ForwardEvaluate(const T&... par_coords) const {
+  constexpr PhysicalPointType_ ForwardEvaluate(const T &...par_coords) const {
     return ForwardEvaluate(PointTypeParametric_{par_coords...});
   }
 
@@ -332,11 +350,11 @@ class BezierSpline {
   /// pointwise addition of the two Beziers
   template <typename PointTypeRHS, typename ScalarRHS>
   constexpr auto operator+(
-      const BezierSpline<parametric_dimension, PointTypeRHS, ScalarRHS>& rhs)
+      const BezierSpline<parametric_dimension, PointTypeRHS, ScalarRHS> &rhs)
       const;
 
   /// Add two splines of same type
-  constexpr BezierSpline& operator+=(BezierSpline rhs);
+  constexpr BezierSpline &operator+=(BezierSpline rhs);
 
   /// Substraction of Two Splines resulting in a new spline that describes the
   /// pointwise addition of the two Beziers
@@ -345,33 +363,33 @@ class BezierSpline {
       BezierSpline<parametric_dimension, PointTypeRHS, ScalarRHS> rhs) const;
 
   /// Add two splines of same type
-  constexpr BezierSpline& operator-=(BezierSpline rhs);
+  constexpr BezierSpline &operator-=(BezierSpline rhs);
 
   /// Check if two splines are equivalent
-  constexpr bool operator==(const BezierSpline& rhs) const;
+  constexpr bool operator==(const BezierSpline &rhs) const;
 
   /// Multiplication of two splines similar to pointwise product
   template <typename PointTypeRHS, typename ScalarRHS>
   constexpr auto operator*(
-      const BezierSpline<parametric_dimension, PointTypeRHS, ScalarRHS>& rhs)
+      const BezierSpline<parametric_dimension, PointTypeRHS, ScalarRHS> &rhs)
       const;
 
   /// Extract single coordinate spline
   constexpr BezierSpline<parametric_dimension, ScalarType, ScalarType>
-  ExtractDimension(const IndexingType& dimension) const;
+  ExtractDimension(const IndexingType &dimension) const;
 
   constexpr BezierSpline<parametric_dimension, PhysicalPointType, ScalarType>
   RaisePower(const IndexingType power) const;
 
   /// Multiplication with scalar
-  constexpr BezierSpline& operator*=(const ScalarType& scalar);
+  constexpr BezierSpline &operator*=(const ScalarType &scalar);
 
   /// Multiplication with scalar RAII
-  constexpr BezierSpline operator*(const ScalarType& scalar) const;
+  constexpr BezierSpline operator*(const ScalarType &scalar) const;
 
   /// Friend injection for reversed order
-  friend constexpr BezierSpline operator*(const ScalarType& scalar,
-                                          const BezierSpline& b) {
+  friend constexpr BezierSpline operator*(const ScalarType &scalar,
+                                          const BezierSpline &b) {
     return b * scalar;
   }
 
@@ -379,22 +397,22 @@ class BezierSpline {
   constexpr bool FitsIntoUnitCube() const;
 
   /// Addition
-  constexpr BezierSpline& operator+=(const PhysicalPointType& point_shift);
+  constexpr BezierSpline &operator+=(const PhysicalPointType &point_shift);
 
   /// Addition
-  constexpr BezierSpline operator+(const PhysicalPointType& point_shift) const;
+  constexpr BezierSpline operator+(const PhysicalPointType &point_shift) const;
 
   /// Friend injection Addition
-  friend constexpr BezierSpline operator+(const PhysicalPointType& point_shift,
-                                          const BezierSpline& original_spline) {
+  friend constexpr BezierSpline operator+(const PhysicalPointType &point_shift,
+                                          const BezierSpline &original_spline) {
     return original_spline + point_shift;
   }
 
   /// Substraction
-  constexpr BezierSpline operator-(const PhysicalPointType& point_shift) const;
+  constexpr BezierSpline operator-(const PhysicalPointType &point_shift) const;
 
   /// Substraction
-  constexpr BezierSpline& operator-=(const PhysicalPointType& point_shift);
+  constexpr BezierSpline &operator-=(const PhysicalPointType &point_shift);
 
   /// Inversion
   constexpr BezierSpline operator-() const;
@@ -417,9 +435,9 @@ class BezierSpline {
    * @param transposition PointType describing the first corner of the nd cuboid
    * @param stretch PointType describing the second corner of the nd cuboid
    */
-  constexpr BezierSpline& TransposeAndScale(
-      const PhysicalPointType& transposition,
-      const PhysicalPointType& scale_vector);
+  constexpr BezierSpline &TransposeAndScale(
+      const PhysicalPointType &transposition,
+      const PhysicalPointType &scale_vector);
 
   /*
    * Fit into unit cube
@@ -427,11 +445,11 @@ class BezierSpline {
    * Takes spline and fits it into the unit cuboid (important for spline
    * composition)
    */
-  constexpr BezierSpline& FitIntoUnitCube();
+  constexpr BezierSpline &FitIntoUnitCube();
 
   /// Friend injection Substraction
-  friend constexpr BezierSpline operator-(const PhysicalPointType& point_shift,
-                                          const BezierSpline& original_spline) {
+  friend constexpr BezierSpline operator-(const PhysicalPointType &point_shift,
+                                          const BezierSpline &original_spline) {
     return -(original_spline - point_shift);
   }
 
@@ -447,7 +465,7 @@ class BezierSpline {
             typename PointTypeRHS, typename ScalarRHS>
   constexpr auto Compose(
       const BezierSpline<parametric_dimension_inner_spline, PointTypeRHS,
-                         ScalarRHS>& inner_function) const;
+                         ScalarRHS> &inner_function) const;
 
   /*
    * Sensitivity of Functional Composition between two splines with respect to
@@ -464,7 +482,7 @@ class BezierSpline {
             typename PointTypeRHS, typename ScalarRHS>
   constexpr auto ComposeSensitivity(
       const BezierSpline<parametric_dimension_inner_spline, PointTypeRHS,
-                         ScalarRHS>& inner_function) const;
+                         ScalarRHS> &inner_function) const;
 
   /*
    * Functional Composition between a polynomial and rational spline
@@ -478,7 +496,7 @@ class BezierSpline {
             typename PointTypeRHS, typename ScalarRHS>
   constexpr auto Compose(
       const RationalBezierSpline<parametric_dimension_inner_spline,
-                                 PointTypeRHS, ScalarRHS>& inner_function)
+                                 PointTypeRHS, ScalarRHS> &inner_function)
       const;
   /*
    * Sensitivity of Functional Composition between two splines with respect to
@@ -495,7 +513,7 @@ class BezierSpline {
             typename PointTypeRHS, typename ScalarRHS>
   constexpr auto ComposeSensitivity(
       const RationalBezierSpline<parametric_dimension_inner_spline,
-                                 PointTypeRHS, ScalarRHS>& inner_function)
+                                 PointTypeRHS, ScalarRHS> &inner_function)
       const;
 
   /*
@@ -507,7 +525,7 @@ class BezierSpline {
    */
   template <typename SplineType>
   constexpr auto Compose(
-      const std::vector<SplineType>& inner_function_group) const;
+      const std::vector<SplineType> &inner_function_group) const;
 
   /*
    * Split the Bezier Spline into two distinct subdivisions
@@ -516,7 +534,7 @@ class BezierSpline {
    * representing the same domain over two splines.
    */
   constexpr std::vector<BezierSpline> SplitAtPosition(
-      const ScalarType& splitting_plane,
+      const ScalarType &splitting_plane,
       const IndexingType splitting_dimension = 0) const;
 
   /*
@@ -526,7 +544,7 @@ class BezierSpline {
    * representing the same domain over several splines.
    */
   constexpr std::vector<BezierSpline> SplitAtPosition(
-      const std::vector<ScalarType>& splitting_planes,
+      const std::vector<ScalarType> &splitting_planes,
       const IndexingType splitting_dimension = 0) const;
 };
 

--- a/src/bezier_spline.inc
+++ b/src/bezier_spline.inc
@@ -36,11 +36,24 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
 constexpr std::array<std::size_t, parametric_dimension> BezierSpline<
     parametric_dimension, PhysicalPointType,
     ScalarType>::LocalToGlobalIndex(const IndexingType& local_index) const {
-  std::array<IndexingType, parametric_dimension> indexList{};
-  for (unsigned int i{0}; i < parametric_dimension; i++) {
-    indexList[i] = (local_index / index_offsets[i]) % (degrees[i] + 1);
+    std::array<IndexingType, parametric_dimension> indexList{};
+    for (unsigned int i{0}; i < parametric_dimension; i++) {
+        indexList[i] = (local_index / index_offsets[i]) % (degrees[i] + 1);
+    }
+    return indexList;
+}
+
+template <std::size_t parametric_dimension, typename PhysicalPointType,
+          typename ScalarType>
+constexpr IndexingType
+BezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
+    GlobalToLocal(const std::array<std::size_t, parametric_dimension>&
+                           local_index) const {
+    IndexingType c_i{local_index[0]};
+    for (unsigned int i{1}; i < parametric_dimension; i++) {
+        c_i += index_offsets[i] * index[i];
   }
-  return indexList;
+  return c_i;
 }
 
 template <std::size_t parametric_dimension, typename PhysicalPointType,
@@ -121,11 +134,7 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
 constexpr const PhysicalPointType&
 BezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::ControlPoint(
     const std::array<IndexingType, parametric_dimension>& index) const {
-  unsigned int c_i{0};
-  for (unsigned int i{}; i < parametric_dimension; i++) {
-    c_i += index_offsets[i] * index[i];
-  }
-  return control_points[c_i];
+  return control_points[GlobalToLocalIndex(index)];
 }
 
 template <std::size_t parametric_dimension, typename PhysicalPointType,
@@ -133,11 +142,7 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
 constexpr PhysicalPointType&
 BezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::ControlPoint(
     const std::array<IndexingType, parametric_dimension>& index) {
-  unsigned int c_i{0};
-  for (unsigned int i{}; i < parametric_dimension; i++) {
-    c_i += index_offsets[i] * index[i];
-  }
-  return control_points[c_i];
+  return control_points[GlobalToLocalIndex(index)];
 }
 
 template <std::size_t parametric_dimension, typename PhysicalPointType,
@@ -224,28 +229,84 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 constexpr BezierSpline<parametric_dimension, PhysicalPointType, ScalarType>
 BezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-    DerivativeWRTParametricDimension(const IndexingType par_dim) const {
-  // Initialize return value and precompute auxiliary values
-  auto new_degrees = degrees;
-  new_degrees[par_dim]--;
-  BezierSpline derivative{new_degrees};
-  const ScalarType factor = static_cast<ScalarType>(degrees[par_dim]);
+    DerivativeWRTParametricDimension(
+        const std::array<IndexingType, parametric_dimension>& orders) const {
+    utils::Logger::Logging(
+        "Calculating derivative splines with orders " +
+            [](std::array<IndexingType, parametric_dimension>& orders)
+            -> std::string {
+            std::string result("[ " + std::to_string(orders[0]));
+            for (IndexingType i{1}; i < parametric_dimension; i++) {
+                result += ", " + std::to_string(orders[0]);
+            }
+            return result + "]";
+        }(orders););
+        
+    // Create a copy of the new degrees which will be updated in every iteration
+    auto new_degrees = degrees;
+    // Create a copy of control points (later be used for in place operations)
+    auto new_control_points = GetControlPoints();
 
-  utils::Logger::Logging("Calculating derivative along parametric dimension " +
-                         std::to_string(par_dim));
+    // For resizing
+    auto compute_number_of_control_points = [&]() {
+        number_of_control_points = 1u;
+        for (unsigned int i{}; i < parametric_dimension; i++) {
+            number_of_control_points *= new_degrees[i] + 1;
+        }
+        return compute_number_of_control_points;
+    };
 
-  // Start looping over all control points in derivative and determine their new
-  // values
-  for (IndexingType i_point{0}; i_point < derivative.GetNumberOfControlPoints();
-       i_point++) {
-    const auto index = derivative.LocalToGlobalIndex(i_point);
-    auto next_index = index;
-    next_index[par_dim]++;
-    derivative.control_points[i_point] =
-        factor * (ControlPoint(next_index) - ControlPoint(index));
-  }
-  utils::Logger::Logging("Derivative successfully computed");
-  return derivative;
+    // Loop over order vector and apply
+    for (IndexingType i_para_dim{}; i_para_dim < parametric_dimension;
+         i_para_dim++) {
+        if (orders[i_para_dim] == 0) {
+            continue;
+        }
+        // Update the new degrees
+        new_degrees[i_para_dim] -= orders[i_para_dim];
+
+        // Compute the constant factor p!/k!
+        const ScalarType& factor = [](const IndexingType& p,
+                                      const IndexingType& k) -> ScalarType {
+            ScalarType factor{p};
+            for (IndexingType i{1}; i < k; i++) {
+                factor *= p - i;
+            }
+            return factor;
+        }(degrees[i_para_dim], orders[i_para_dim]);
+
+        // Start looping over all control points in derivative and determine
+        // their new values
+        for (IndexingType i_point{0};
+             i_point < compute_number_of_control_points(); i_point++) {
+            auto multi_index = global_index(i_point);
+            const auto i_point_index = GlobalToLocalIndex(multi_index);
+            for (IndexingType j_point_offset{1};
+                 j_point_offset <= orders[i_para_dim]; j_point_offset++) {
+                multi_index[i_para_dim]++;
+                control_points[i_point_index] +=
+                    utils::FastBinomialCoefficient::choose(orders[i_para_dim],
+                                                           j_point_offset) *
+                    new_control_points[GlobalToLocalIndex(multi_index)] *
+                    (j_point_offset % 2 ? 1.0 : -1.0);
+            }
+            new_control_points[i_point_index] *= factor;
+        }
+    }
+
+    // Create new spline and 
+    BezierSpline derivative{new_degrees};
+
+    // Copy all control points into the vector 
+    for (IndexingType i_point{};
+         i_point < derivative.GetNumberOfControlPoints(); i_point++) {
+        derivative.GetControlPoints()[i_point] =
+            new_control_points[GlobalToLocal(
+                derivatives.LocalToGlobal(i_point))];
+    }
+
+    utils::Logger::Logging("Derivative successfully computed");
+    return BezierSpline{new_degrees, new_control_points};
 }
 
 template <std::size_t parametric_dimension, typename PhysicalPointType,

--- a/src/bezier_spline.inc
+++ b/src/bezier_spline.inc
@@ -36,22 +36,23 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
 constexpr std::array<std::size_t, parametric_dimension> BezierSpline<
     parametric_dimension, PhysicalPointType,
     ScalarType>::LocalToGlobalIndex(const IndexingType& local_index) const {
-    std::array<IndexingType, parametric_dimension> indexList{};
-    for (unsigned int i{0}; i < parametric_dimension; i++) {
-        indexList[i] = (local_index / index_offsets[i]) % (degrees[i] + 1);
-    }
-    return indexList;
+  std::array<IndexingType, parametric_dimension> indexList{};
+  for (unsigned int i{0}; i < parametric_dimension; i++) {
+    indexList[i] = (local_index / index_offsets[i]) % (degrees[i] + 1);
+  }
+  return indexList;
 }
 
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
-constexpr IndexingType
+constexpr typename BezierSpline<parametric_dimension, PhysicalPointType,
+                                ScalarType>::IndexingType_
 BezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-    GlobalToLocal(const std::array<std::size_t, parametric_dimension>&
+    GlobalToLocalIndex(const std::array<std::size_t, parametric_dimension>&
                            local_index) const {
-    IndexingType c_i{local_index[0]};
-    for (unsigned int i{1}; i < parametric_dimension; i++) {
-        c_i += index_offsets[i] * index[i];
+  IndexingType c_i{local_index[0]};
+  for (unsigned int i{1}; i < parametric_dimension; i++) {
+    c_i += index_offsets[i] * local_index[i];
   }
   return c_i;
 }
@@ -231,82 +232,97 @@ constexpr BezierSpline<parametric_dimension, PhysicalPointType, ScalarType>
 BezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
     DerivativeWRTParametricDimension(
         const std::array<IndexingType, parametric_dimension>& orders) const {
-    utils::Logger::Logging(
-        "Calculating derivative splines with orders " +
-            [](std::array<IndexingType, parametric_dimension>& orders)
-            -> std::string {
-            std::string result("[ " + std::to_string(orders[0]));
-            for (IndexingType i{1}; i < parametric_dimension; i++) {
-                result += ", " + std::to_string(orders[0]);
-            }
-            return result + "]";
-        }(orders););
-        
-    // Create a copy of the new degrees which will be updated in every iteration
-    auto new_degrees = degrees;
-    // Create a copy of control points (later be used for in place operations)
-    auto new_control_points = GetControlPoints();
-
-    // For resizing
-    auto compute_number_of_control_points = [&]() {
-        number_of_control_points = 1u;
-        for (unsigned int i{}; i < parametric_dimension; i++) {
-            number_of_control_points *= new_degrees[i] + 1;
+  utils::Logger::Logging(
+      "Calculating derivative splines with orders " +
+          [](const std::array<IndexingType, parametric_dimension>& orders)
+          -> std::string {
+        std::string result("[ " + std::to_string(orders[0]));
+        for (IndexingType i{1}; i < parametric_dimension; i++) {
+          result += ", " + std::to_string(orders[i]);
         }
-        return compute_number_of_control_points;
-    };
+        return result + "]";
+      }(orders));
 
-    // Loop over order vector and apply
-    for (IndexingType i_para_dim{}; i_para_dim < parametric_dimension;
-         i_para_dim++) {
-        if (orders[i_para_dim] == 0) {
-            continue;
-        }
-        // Update the new degrees
-        new_degrees[i_para_dim] -= orders[i_para_dim];
+  // Create a copy of the new degrees which will be updated in every iteration
+  auto new_degrees = degrees;
+  // Create a copy of control points (later be used for in place operations)
+  auto new_control_points = GetControlPoints();
 
-        // Compute the constant factor p!/k!
-        const ScalarType& factor = [](const IndexingType& p,
-                                      const IndexingType& k) -> ScalarType {
-            ScalarType factor{p};
-            for (IndexingType i{1}; i < k; i++) {
-                factor *= p - i;
-            }
-            return factor;
-        }(degrees[i_para_dim], orders[i_para_dim]);
-
-        // Start looping over all control points in derivative and determine
-        // their new values
-        for (IndexingType i_point{0};
-             i_point < compute_number_of_control_points(); i_point++) {
-            auto multi_index = global_index(i_point);
-            const auto i_point_index = GlobalToLocalIndex(multi_index);
-            for (IndexingType j_point_offset{1};
-                 j_point_offset <= orders[i_para_dim]; j_point_offset++) {
-                multi_index[i_para_dim]++;
-                control_points[i_point_index] +=
-                    utils::FastBinomialCoefficient::choose(orders[i_para_dim],
-                                                           j_point_offset) *
-                    new_control_points[GlobalToLocalIndex(multi_index)] *
-                    (j_point_offset % 2 ? 1.0 : -1.0);
-            }
-            new_control_points[i_point_index] *= factor;
-        }
+  // Determine how many control points are expected in the current spline
+  auto compute_number_of_control_points = [&new_degrees]() -> IndexingType {
+    IndexingType number_of_control_points = 1u;
+    for (unsigned int i{}; i < parametric_dimension; i++) {
+      number_of_control_points *= new_degrees[i] + 1;
     }
+    return number_of_control_points;
+  };
 
-    // Create new spline and 
-    BezierSpline derivative{new_degrees};
-
-    // Copy all control points into the vector 
-    for (IndexingType i_point{};
-         i_point < derivative.GetNumberOfControlPoints(); i_point++) {
-        derivative.GetControlPoints()[i_point] =
-            new_control_points[GlobalToLocal(
-                derivatives.LocalToGlobal(i_point))];
+  // Determine control point IDs using current values of new_degrees
+  auto global_id_with_new_degrees = [&new_degrees](IndexingType global_id)
+      -> std::array<IndexingType, parametric_dimension> {
+    std::array<IndexingType, parametric_dimension> multi_index{
+        global_id % (new_degrees[0] + 1)};
+    for (unsigned int i_para{1}; i_para < parametric_dimension; i_para++) {
+      global_id /= (new_degrees[i_para - 1] + 1);
+      multi_index[i_para] = global_id % (new_degrees[i_para] + 1);
     }
+    return multi_index;
+  };
 
-    utils::Logger::Logging("Derivative successfully computed");
-    return BezierSpline{new_degrees, new_control_points};
+  // Loop over order vector and apply
+  for (IndexingType i_para_dim{}; i_para_dim < parametric_dimension;
+       i_para_dim++) {
+    if (orders[i_para_dim] == 0) {
+      continue;
+    }
+    // Update the new degrees
+    new_degrees[i_para_dim] -= orders[i_para_dim];
+
+    // Compute the constant factor p!/k!
+    const ScalarType& factor = [](const IndexingType& p,
+                                  const IndexingType& k) -> ScalarType {
+      ScalarType factor{static_cast<ScalarType>(p)};
+      for (IndexingType i{1}; i < k; i++) {
+        factor *= p - i;
+      }
+      return factor;
+    }(degrees[i_para_dim], orders[i_para_dim]);
+
+    // Start looping over all control points in derivative and determine
+    // their new values
+    for (IndexingType i_point{0}; i_point < compute_number_of_control_points();
+         i_point++) {
+      auto multi_index = global_id_with_new_degrees(i_point);
+      const auto i_point_index = GlobalToLocalIndex(multi_index);
+      for (IndexingType j_point_offset{1}; j_point_offset <= orders[i_para_dim];
+           j_point_offset++) {
+        multi_index[i_para_dim]++;
+        const ScalarType local_coefficient =
+            (j_point_offset % 2 == 0 ? 1.0 : -1.0) *
+            utils::FastBinomialCoefficient::choose(orders[i_para_dim],
+                                                   j_point_offset);
+        new_control_points[i_point_index] +=
+            local_coefficient *
+            new_control_points[GlobalToLocalIndex(multi_index)];
+      }
+      new_control_points[i_point_index] *=
+          (orders[i_para_dim] % 2 == 0 ? 1.0 : -1.0) * factor;
+    }
+  }
+
+  // Create new spline and
+  BezierSpline derivative{new_degrees};
+
+  // Copy all control points into the vector
+  for (IndexingType i_point{}; i_point < derivative.GetNumberOfControlPoints();
+       i_point++) {
+    derivative.GetControlPoints()[i_point] =
+        new_control_points[GlobalToLocalIndex(
+            derivative.LocalToGlobalIndex(i_point))];
+  }
+
+  utils::Logger::Logging("Derivative successfully computed");
+  return derivative;
 }
 
 template <std::size_t parametric_dimension, typename PhysicalPointType,

--- a/src/rational_bezier_spline.hpp
+++ b/src/rational_bezier_spline.hpp
@@ -521,19 +521,34 @@ class RationalBezierSpline {
   }
 
   /// Check if can be used for composition
-  constexpr bool FitsIntoUnitCube() const {
-    return weighted_spline_.FitsIntoUnitCube();
-  };
+  constexpr bool FitsIntoUnitCube() const;
 
   /// Get maximum restricting corner of spline
-  constexpr PhysicalPointType MaximumCorner() const {
-    return weighted_spline_.MaximumCorner();
-  };
+  constexpr PhysicalPointType MaximumCorner() const;
 
   /// Get minimum restricting corner of spline
-  constexpr PhysicalPointType MinimumCorner() const {
-    return weighted_spline_.MinimumCorner();
-  };
+  constexpr PhysicalPointType MinimumCorner() const;
+
+  /*
+   * Retrieve multidimensional indices
+   *
+   * @param local_indices single value index as control point index
+   */
+  constexpr std::array<IndexingType, parametric_dimension> LocalToGlobalIndex(
+      const IndexingType& local_index) const {
+    return weight_function_.LocalToGlobalIndex(local_index);
+  }
+
+  /*
+   * Retrieve global scalar index
+   *
+   * @param global_idex Array index type as std::array
+   */
+  constexpr IndexingType GlobalToLocalIndex(
+      const std::array<IndexingType, parametric_dimension>& global_index)
+      const {
+    return weight_function_.GlobalToLocalIndex(global_index);
+  }
 };
 
 #include "bezman/src/rational_bezier_spline.inc"

--- a/src/rational_bezier_spline.hpp
+++ b/src/rational_bezier_spline.hpp
@@ -206,12 +206,12 @@ class RationalBezierSpline {
 
   // Get the weight function spline as const reference
   constexpr const PolynomialScalarBezier& GetWeightFunctionSpline() const {
-      return weight_function_;
+    return weight_function_;
   }
 
   // Get the weighted spline function as const reference
-  constexpr const PolynomialScalarBezier& GetNumeratorSpline() const {
-      return weighted_spline_;
+  constexpr const PolynomialBezier& GetNumeratorSpline() const {
+    return weighted_spline_;
   }
 
   /// Retrieve single control point from local indices
@@ -357,10 +357,10 @@ class RationalBezierSpline {
    * @brief  Derivative along a specific parametric dimension
    *
    * This function is implemented using the Quotient-rule for derivatives
-   * 
+   *
    * Very costly, please use carefully
-   * 
-   * @param orders 
+   *
+   * @param orders
    */
   constexpr RationalBezierSpline DerivativeWRTParametricDimension(
       const std::array<IndexingType, parametric_dimension>& orders) const;

--- a/src/rational_bezier_spline.hpp
+++ b/src/rational_bezier_spline.hpp
@@ -206,7 +206,12 @@ class RationalBezierSpline {
 
   // Get the weight function spline as const reference
   constexpr const PolynomialScalarBezier& GetWeightFunctionSpline() const {
-    return weight_function_;
+      return weight_function_;
+  }
+
+  // Get the weighted spline function as const reference
+  constexpr const PolynomialScalarBezier& GetNumeratorSpline() const {
+      return weighted_spline_;
   }
 
   /// Retrieve single control point from local indices
@@ -352,9 +357,13 @@ class RationalBezierSpline {
    * @brief  Derivative along a specific parametric dimension
    *
    * This function is implemented using the Quotient-rule for derivatives
+   * 
+   * Very costly, please use carefully
+   * 
+   * @param orders 
    */
   constexpr RationalBezierSpline DerivativeWRTParametricDimension(
-      const IndexingType par_dim) const;
+      const std::array<IndexingType, parametric_dimension>& orders) const;
 
   //-------------------  Operator overloads
 

--- a/src/rational_bezier_spline.inc
+++ b/src/rational_bezier_spline.inc
@@ -40,7 +40,7 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
 constexpr PhysicalPointType
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
     ControlPoint(
-        const std::array<IndexingType, parametric_dimension>& index) const {
+        const std::array<IndexingType, parametric_dimension> &index) const {
   return weighted_spline_.ControlPoint(index) /
          weight_function_.ControlPoint(index);
 }
@@ -48,7 +48,7 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 template <typename... T>
-constexpr PhysicalPointType&
+constexpr PhysicalPointType &
 RationalBezierSpline<parametric_dimension, PhysicalPointType,
                      ScalarType>::WeightedControlPoint(const T... index) {
   static_assert(sizeof...(T) == parametric_dimension,
@@ -59,7 +59,7 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType,
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 template <typename... T>
-constexpr const PhysicalPointType&
+constexpr const PhysicalPointType &
 RationalBezierSpline<parametric_dimension, PhysicalPointType,
                      ScalarType>::WeightedControlPoint(const T... index) const {
   static_assert(sizeof...(T) == parametric_dimension,
@@ -69,26 +69,26 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType,
 
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
-constexpr PhysicalPointType&
+constexpr PhysicalPointType &
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
     WeightedControlPoint(
-        const std::array<IndexingType, parametric_dimension>& index) {
+        const std::array<IndexingType, parametric_dimension> &index) {
   return weighted_spline_.ControlPoint(index);
 }
 
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
-constexpr const PhysicalPointType&
+constexpr const PhysicalPointType &
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
     WeightedControlPoint(
-        const std::array<IndexingType, parametric_dimension>& index) const {
+        const std::array<IndexingType, parametric_dimension> &index) const {
   return weighted_spline_.ControlPoint(index);
 }
 
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 template <typename... T>
-constexpr ScalarType&
+constexpr ScalarType &
 RationalBezierSpline<parametric_dimension, PhysicalPointType,
                      ScalarType>::Weight(const T... index) {
   static_assert(sizeof...(T) == parametric_dimension,
@@ -99,7 +99,7 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType,
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 template <typename... T>
-constexpr const ScalarType&
+constexpr const ScalarType &
 RationalBezierSpline<parametric_dimension, PhysicalPointType,
                      ScalarType>::Weight(const T... index) const {
   static_assert(sizeof...(T) == parametric_dimension,
@@ -109,17 +109,17 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType,
 
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
-constexpr ScalarType&
+constexpr ScalarType &
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-    Weight(const std::array<IndexingType, parametric_dimension>& index) {
+    Weight(const std::array<IndexingType, parametric_dimension> &index) {
   return weight_function_.ControlPoint(index);
 }
 
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
-constexpr const ScalarType&
+constexpr const ScalarType &
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-    Weight(const std::array<IndexingType, parametric_dimension>& index) const {
+    Weight(const std::array<IndexingType, parametric_dimension> &index) const {
   return weight_function_.ControlPoint(index);
 }
 
@@ -127,7 +127,7 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 constexpr PhysicalPointType RationalBezierSpline<
     parametric_dimension, PhysicalPointType,
-    ScalarType>::Evaluate(const PointTypeParametric_& par_coords) const {
+    ScalarType>::Evaluate(const PointTypeParametric_ &par_coords) const {
   return weighted_spline_.Evaluate(par_coords) /
          weight_function_.Evaluate(par_coords);
 }
@@ -136,7 +136,7 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 constexpr std::vector<ScalarType> RationalBezierSpline<
     parametric_dimension, PhysicalPointType,
-    ScalarType>::BasisFunctions(const PointTypeParametric_& par_coords) const {
+    ScalarType>::BasisFunctions(const PointTypeParametric_ &par_coords) const {
   // Check sanity
   assert(CheckSplineCompatibility());
 
@@ -156,7 +156,7 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 constexpr std::vector<ScalarType>
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-    UnweightedBasisFunctions(const PointTypeParametric_& par_coords) const {
+    UnweightedBasisFunctions(const PointTypeParametric_ &par_coords) const {
   // Check sanity
   assert(CheckSplineCompatibility());
 
@@ -188,7 +188,7 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 constexpr std::array<std::vector<ScalarType>, parametric_dimension>
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-    BasisFunctionContributions(const PointTypeParametric_& par_coords) const {
+    BasisFunctionContributions(const PointTypeParametric_ &par_coords) const {
   // Basis function of weight function and weighted spline are equivalent
   return weighted_spline_.BasisFunctionContributions(par_coords);
 }
@@ -197,7 +197,7 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 constexpr PhysicalPointType RationalBezierSpline<
     parametric_dimension, PhysicalPointType,
-    ScalarType>::ForwardEvaluate(const PointTypeParametric_& par_coords) const {
+    ScalarType>::ForwardEvaluate(const PointTypeParametric_ &par_coords) const {
   // Check sanity
   assert(CheckSplineCompatibility());
 
@@ -222,8 +222,8 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
 constexpr PhysicalPointType
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
     EvaluateDerivative(
-        const PointTypeParametric_& par_coords,
-        const std::array<std::size_t, parametric_dimension>& nth_derivs) const {
+        const PointTypeParametric_ &par_coords,
+        const std::array<std::size_t, parametric_dimension> &nth_derivs) const {
   // Define lambdas to switch between local indexing with coordinate style
   // indexing to global, scalar indexing
   // example: for nth (2,1,4) : (1,0,0)->1, (1,1,0)->4
@@ -245,7 +245,7 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
   // Local (coordinate-style) indexing to global
   auto global_ids_ =
       [&nth_derivs](
-          const std::array<std::size_t, parametric_dimension>& req_derivs)
+          const std::array<std::size_t, parametric_dimension> &req_derivs)
       -> std::size_t {
     std::size_t id{};
     std::size_t offset{1};
@@ -260,8 +260,8 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
 
   // Check if requested derivative is "subset" to current derivative
   auto is_not_subset_ =
-      [](const std::array<std::size_t, parametric_dimension>& req_derivs_max,
-         const std::array<std::size_t, parametric_dimension>& req_derivs)
+      [](const std::array<std::size_t, parametric_dimension> &req_derivs_max,
+         const std::array<std::size_t, parametric_dimension> &req_derivs)
       -> bool {
     for (std::size_t i_pd{}; i_pd < parametric_dimension; i_pd++) {
       if (req_derivs[i_pd] > req_derivs_max[i_pd]) return true;
@@ -326,8 +326,8 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
 constexpr std::vector<ScalarType>
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
     BasisFunctionsDerivatives(
-        const PointTypeParametric_& par_coords,
-        const std::array<std::size_t, parametric_dimension>& nth_derivs) const {
+        const PointTypeParametric_ &par_coords,
+        const std::array<std::size_t, parametric_dimension> &nth_derivs) const {
   // Define lambdas to switch between local indexing with coordinate style
   // indexing to global, scalar indexing
   // example: for nth (2,1,4) : (1,0,0)->1, (1,1,0)->4
@@ -349,7 +349,7 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
   // Local (coordinate-style) indexing to global
   auto global_ids_ =
       [&nth_derivs](
-          const std::array<std::size_t, parametric_dimension>& req_derivs)
+          const std::array<std::size_t, parametric_dimension> &req_derivs)
       -> std::size_t {
     std::size_t id{};
     std::size_t offset{1};
@@ -364,8 +364,8 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
 
   // Check if requested derivative is "subset" to current derivative
   auto is_not_subset_ =
-      [](const std::array<std::size_t, parametric_dimension>& req_derivs_max,
-         const std::array<std::size_t, parametric_dimension>& req_derivs)
+      [](const std::array<std::size_t, parametric_dimension> &req_derivs_max,
+         const std::array<std::size_t, parametric_dimension> &req_derivs)
       -> bool {
     for (std::size_t i_pd{}; i_pd < parametric_dimension; i_pd++) {
       if (req_derivs[i_pd] > req_derivs_max[i_pd]) return true;
@@ -437,9 +437,9 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 constexpr RationalBezierSpline<parametric_dimension, PhysicalPointType,
-                               ScalarType>&
-RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-    OrderElevateAlongParametricDimension(const IndexingType par_dim) {
+                               ScalarType>
+    &RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
+        OrderElevateAlongParametricDimension(const IndexingType par_dim) {
   weighted_spline_.OrderElevateAlongParametricDimension(par_dim);
   weight_function_.OrderElevateAlongParametricDimension(par_dim);
   // Check sanity
@@ -452,7 +452,7 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
 constexpr std::vector<
     RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>>
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-    SplitAtPosition(const ScalarType& splitting_planes,
+    SplitAtPosition(const ScalarType &splitting_planes,
                     const IndexingType splitting_dimension) const {
   const auto weighted_splines =
       weighted_spline_.SplitAtPosition(splitting_planes, splitting_dimension);
@@ -468,7 +468,7 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
 constexpr std::vector<
     RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>>
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-    SplitAtPosition(const std::vector<ScalarType>& splitting_planes,
+    SplitAtPosition(const std::vector<ScalarType> &splitting_planes,
                     const IndexingType splitting_dimension) const {
   // Init return value
   using ReturnType = std::vector<RationalBezierSpline>;
@@ -511,7 +511,7 @@ constexpr RationalBezierSpline<parametric_dimension, PhysicalPointType,
                                ScalarType>
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
     DerivativeWRTParametricDimension(
-        const std::array<IndexingType, parametric_dimension>& orders) const {
+        const std::array<IndexingType, parametric_dimension> &orders) const {
   // Implemented using Quotient-rule
   // There is currently no generalized high order generalization of the
   // quotient rule, here we use a one by one derivative, involving copies each
@@ -525,9 +525,9 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
 
   for (IndexingType i_para_dim{}; i_para_dim < parametric_dimension;
        i_para_dim++) {
+    std::array<IndexingType, parametric_dimension> order_{};
+    order_[i_para_dim]++;
     for (IndexingType i_order{}; i_order < orders[i_para_dim]; i_order++) {
-      std::array<IndexingType, parametric_dimension> order_{};
-      order_[i_para_dim]++;
       derivative = RationalBezierSpline(
           // u' * w - w' * u
           ((derivative.GetNumeratorSpline().DerivativeWRTParametricDimension(
@@ -548,9 +548,9 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 constexpr RationalBezierSpline<parametric_dimension, PhysicalPointType,
-                               ScalarType>&
-RationalBezierSpline<parametric_dimension, PhysicalPointType,
-                     ScalarType>::operator*=(const ScalarType& scalar) {
+                               ScalarType>
+    &RationalBezierSpline<parametric_dimension, PhysicalPointType,
+                          ScalarType>::operator*=(const ScalarType &scalar) {
   // Multiplication only reflects in the weighted spline
   weighted_spline_ *= scalar;
   // Check sanity
@@ -563,7 +563,7 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
 constexpr RationalBezierSpline<parametric_dimension, PhysicalPointType,
                                ScalarType>
 RationalBezierSpline<parametric_dimension, PhysicalPointType,
-                     ScalarType>::operator*(const ScalarType& scalar) const {
+                     ScalarType>::operator*(const ScalarType &scalar) const {
   // Multiplication only reflects in the weighted spline
   return RationalBezierSpline(weighted_spline_ * scalar, weight_function_);
 }
@@ -571,9 +571,9 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType,
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 constexpr RationalBezierSpline<parametric_dimension, PhysicalPointType,
-                               ScalarType>&
-RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-operator+=(const PhysicalPointType& point_shift) {
+                               ScalarType>
+    &RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
+    operator+=(const PhysicalPointType &point_shift) {
   // Add up contributions to control points with weights
   for (IndexingType i_ctps{};
        i_ctps < weighted_spline_.GetNumberOfControlPoints(); i_ctps++) {
@@ -590,7 +590,7 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
 constexpr RationalBezierSpline<parametric_dimension, PhysicalPointType,
                                ScalarType>
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-operator+(const PhysicalPointType& point_shift) const {
+operator+(const PhysicalPointType &point_shift) const {
   // Pass to operator +=
   RationalBezierSpline return_spline{weighted_spline_, weight_function_};
   return_spline += point_shift;
@@ -600,9 +600,9 @@ operator+(const PhysicalPointType& point_shift) const {
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 constexpr RationalBezierSpline<parametric_dimension, PhysicalPointType,
-                               ScalarType>&
-RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-operator-=(const PhysicalPointType& point_shift) {
+                               ScalarType>
+    &RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
+    operator-=(const PhysicalPointType &point_shift) {
   // Add up contributions to control points with weights
   for (IndexingType i_ctps{};
        i_ctps < weighted_spline_.GetNumberOfControlPoints(); i_ctps++) {
@@ -617,7 +617,7 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
 constexpr RationalBezierSpline<parametric_dimension, PhysicalPointType,
                                ScalarType>
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-operator-(const PhysicalPointType& point_shift) const {
+operator-(const PhysicalPointType &point_shift) const {
   // Pass to operator +=
   RationalBezierSpline return_spline{weighted_spline_, weight_function_};
   return_spline -= point_shift;
@@ -641,7 +641,7 @@ template <typename PointTypeRHS, typename ScalarRHS>
 constexpr auto
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
 operator+(const RationalBezierSpline<parametric_dimension, PointTypeRHS,
-                                     ScalarRHS>& rhs) const {
+                                     ScalarRHS> &rhs) const {
   if (weight_function_ == rhs.weight_function_) {
     return RationalBezierSpline{weighted_spline_ + rhs.weighted_spline_,
                                 weight_function_};
@@ -655,10 +655,10 @@ operator+(const RationalBezierSpline<parametric_dimension, PointTypeRHS,
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 constexpr RationalBezierSpline<parametric_dimension, PhysicalPointType,
-                               ScalarType>&
-RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-operator+=(const RationalBezierSpline<parametric_dimension, PhysicalPointType,
-                                      ScalarType>& rhs) {
+                               ScalarType>
+    &RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
+    operator+=(const RationalBezierSpline<parametric_dimension,
+                                          PhysicalPointType, ScalarType> &rhs) {
   if (weight_function_ == rhs.weight_function_) {
     weighted_spline_ += rhs.weighted_spline_;
     return (*this);
@@ -678,7 +678,7 @@ template <typename PointTypeRHS, typename ScalarRHS>
 constexpr auto
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
 operator-(const RationalBezierSpline<parametric_dimension, PointTypeRHS,
-                                     ScalarRHS>& rhs) const {
+                                     ScalarRHS> &rhs) const {
   if (weight_function_ == rhs.weight_function_) {
     return RationalBezierSpline{weighted_spline_ - rhs.weighted_spline_,
                                 weight_function_};
@@ -692,10 +692,10 @@ operator-(const RationalBezierSpline<parametric_dimension, PointTypeRHS,
 template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 constexpr RationalBezierSpline<parametric_dimension, PhysicalPointType,
-                               ScalarType>&
-RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-operator-=(const RationalBezierSpline<parametric_dimension, PhysicalPointType,
-                                      ScalarType>& rhs) {
+                               ScalarType>
+    &RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
+    operator-=(const RationalBezierSpline<parametric_dimension,
+                                          PhysicalPointType, ScalarType> &rhs) {
   if (weight_function_ == rhs.weight_function_) {
     weighted_spline_ -= rhs.weighted_spline_;
     return (*this);
@@ -715,7 +715,7 @@ template <typename PointTypeRHS, typename ScalarRHS>
 constexpr auto
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
 operator*(const RationalBezierSpline<parametric_dimension, PointTypeRHS,
-                                     ScalarRHS>& rhs) const {
+                                     ScalarRHS> &rhs) const {
   return RationalBezierSpline<parametric_dimension,
                               decltype(PhysicalPointType{} * PointTypeRHS{}),
                               decltype(ScalarType{} * ScalarRHS{})>{
@@ -727,7 +727,7 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
           typename ScalarType>
 constexpr BezierSpline<parametric_dimension, ScalarType, ScalarType>
 RationalBezierSpline<parametric_dimension, PhysicalPointType,
-                     ScalarType>::ExtractDimension(const std::size_t& dimension)
+                     ScalarType>::ExtractDimension(const std::size_t &dimension)
     const {
   return weighted_spline_.ExtractDimension(dimension);
 }
@@ -740,7 +740,7 @@ constexpr auto
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
     ComposeSensitivity(
         const BezierSpline<parametric_dimension_inner_spline, PointTypeRHS,
-                           ScalarRHS>& inner_function) const {
+                           ScalarRHS> &inner_function) const {
   // Return value Spline type
   using ReturnSplineType =
       RationalBezierSpline<parametric_dimension_inner_spline,
@@ -748,9 +748,9 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
                            decltype(ScalarType_{} * ScalarRHS{})>;
 
   // Precompute numerators
-  const auto& numerator_derivatives =
+  const auto &numerator_derivatives =
       weighted_spline_.ComposeSensitivity(inner_function);
-  const auto& denominator_spline = weight_function_.Compose(inner_function);
+  const auto &denominator_spline = weight_function_.Compose(inner_function);
 
   // Init return value
   std::vector<ReturnSplineType> return_value{};
@@ -777,7 +777,7 @@ constexpr auto
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
     ComposeSensitivity(
         const RationalBezierSpline<parametric_dimension_inner_spline,
-                                   PointTypeRHS, ScalarRHS>& inner_function)
+                                   PointTypeRHS, ScalarRHS> &inner_function)
         const {
   // Return value Spline type
   using ReturnSplineType =
@@ -786,9 +786,9 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
                            decltype(ScalarType_{} * ScalarRHS{})>;
 
   // Precompute numerators
-  const auto& numerator_derivatives =
+  const auto &numerator_derivatives =
       weighted_spline_.ComposeNumeratorSensitivity(inner_function);
-  const auto& denominator_spline =
+  const auto &denominator_spline =
       weight_function_.ComposeNumeratorSpline(inner_function);
 
   // Init return value
@@ -843,10 +843,11 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType,
   PhysicalPointType minimum{ControlPoint(LocalToGlobalIndex(0))};
   for (IndexingType i{1}; i < GetNumberOfControlPoints(); i++) {
     if constexpr (std::is_arithmetic_v<PhysicalPointType>) {
-      minimum = std::min(minimum, ControlPoint(LocalToGlobalIndex(i)));
+      minimum =
+          std::min(minimum, GetWeightedControlPoints()[i] / GetWeights()[i]);
     } else {
-      const PhysicalPointType& control_point_reference =
-          ControlPoint(LocalToGlobalIndex(i));
+      const PhysicalPointType &control_point_reference =
+          GetWeightedControlPoints()[i] / GetWeights()[i];
       for (IndexingType i_dim{}; i_dim < PhysicalPointType::kSpatialDimension;
            i_dim++) {
         minimum[i_dim] =
@@ -869,10 +870,11 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType,
   PhysicalPointType maximum{ControlPoint(LocalToGlobalIndex(0))};
   for (IndexingType i{1}; i < GetNumberOfControlPoints(); i++) {
     if constexpr (std::is_arithmetic_v<PhysicalPointType>) {
-      maximum = std::max(maximum, ControlPoint(LocalToGlobalIndex(i)));
+      maximum =
+          std::max(maximum, GetWeightedControlPoints()[i] / GetWeights()[i]);
     } else {
-      const PhysicalPointType& control_point_reference =
-          ControlPoint(LocalToGlobalIndex(i));
+      const PhysicalPointType &control_point_reference =
+          GetWeightedControlPoints()[i] / GetWeights()[i];
       for (IndexingType i_dim{}; i_dim < PhysicalPointType::kSpatialDimension;
            i_dim++) {
         maximum[i_dim] =

--- a/src/rational_bezier_spline.inc
+++ b/src/rational_bezier_spline.inc
@@ -510,19 +510,39 @@ template <std::size_t parametric_dimension, typename PhysicalPointType,
 constexpr RationalBezierSpline<parametric_dimension, PhysicalPointType,
                                ScalarType>
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
-    DerivativeWRTParametricDimension(const IndexingType par_dim) const {
-  // Implemented using Quotient-rule
-  // Note that the numerator spline needs to be order elevated to match
-  // denominator's order
-  return RationalBezierSpline(
-      // u' * w - w' * u
-      (weighted_spline_.DerivativeWRTParametricDimension(par_dim) *
-           weight_function_ -
-       weight_function_.DerivativeWRTParametricDimension(par_dim) *
-           weighted_spline_)
-          .OrderElevateAlongParametricDimension(par_dim),
-      // v^2
-      weight_function_ * weight_function_);
+    DerivativeWRTParametricDimension(
+        const std::array<IndexingType, parametric_dimension>& orders) const {
+    // Implemented using Quotient-rule
+    // There is currently no generalized high order generalization of the
+    // quotient rule, here we use a one by one derivative, involving copies each
+    // time. This operation is very expensive, please use carefully.
+
+    // Note that the numerator spline needs to be order elevated to match
+    // denominator's order
+
+    // Initialize return value
+    RationalBezierSpline derivative{*this};
+
+    for (IndexingType i_para_dim{}; i_para_dim < parametric_dimension;
+         i_para_dim++) {
+        for (IndexingType i_order{}; i_order < orders[i_para_dim]; i_order++) {
+            std::array<IndexingType, parametric_dimension> order_{};
+            order_[i_para_dim]++;
+            RationalBezierSpline(
+                // u' * w - w' * u
+                (derivative.GetNumeratorSpline()
+                         .DerivativeWRTParametricDimension(order_) *
+                     weight_function_ -
+                 derivative.GetWeightFunctionSpline()
+                         .DerivativeWRTParametricDimension(order_) *
+                     derivative.GetNumeratorSpline())
+                    .OrderElevateAlongParametricDimension(i_para_dim),
+                // v^2
+                derivative.GetWeightFunctionSpline() *
+                    derivative.GetWeightFunctionSpline())
+        }
+    }
+    return derivative;
 }
 
 template <std::size_t parametric_dimension, typename PhysicalPointType,

--- a/src/rational_bezier_spline.inc
+++ b/src/rational_bezier_spline.inc
@@ -512,37 +512,37 @@ constexpr RationalBezierSpline<parametric_dimension, PhysicalPointType,
 RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
     DerivativeWRTParametricDimension(
         const std::array<IndexingType, parametric_dimension>& orders) const {
-    // Implemented using Quotient-rule
-    // There is currently no generalized high order generalization of the
-    // quotient rule, here we use a one by one derivative, involving copies each
-    // time. This operation is very expensive, please use carefully.
+  // Implemented using Quotient-rule
+  // There is currently no generalized high order generalization of the
+  // quotient rule, here we use a one by one derivative, involving copies each
+  // time. This operation is very expensive, please use carefully.
 
-    // Note that the numerator spline needs to be order elevated to match
-    // denominator's order
+  // Note that the numerator spline needs to be order elevated to match
+  // denominator's order
 
-    // Initialize return value
-    RationalBezierSpline derivative{*this};
+  // Initialize return value
+  RationalBezierSpline derivative{*this};
 
-    for (IndexingType i_para_dim{}; i_para_dim < parametric_dimension;
-         i_para_dim++) {
-        for (IndexingType i_order{}; i_order < orders[i_para_dim]; i_order++) {
-            std::array<IndexingType, parametric_dimension> order_{};
-            order_[i_para_dim]++;
-            RationalBezierSpline(
-                // u' * w - w' * u
-                (derivative.GetNumeratorSpline()
-                         .DerivativeWRTParametricDimension(order_) *
-                     weight_function_ -
-                 derivative.GetWeightFunctionSpline()
-                         .DerivativeWRTParametricDimension(order_) *
-                     derivative.GetNumeratorSpline())
-                    .OrderElevateAlongParametricDimension(i_para_dim),
-                // v^2
-                derivative.GetWeightFunctionSpline() *
-                    derivative.GetWeightFunctionSpline())
-        }
+  for (IndexingType i_para_dim{}; i_para_dim < parametric_dimension;
+       i_para_dim++) {
+    for (IndexingType i_order{}; i_order < orders[i_para_dim]; i_order++) {
+      std::array<IndexingType, parametric_dimension> order_{};
+      order_[i_para_dim]++;
+      derivative = RationalBezierSpline(
+          // u' * w - w' * u
+          ((derivative.GetNumeratorSpline().DerivativeWRTParametricDimension(
+                order_) *
+            derivative.GetWeightFunctionSpline()) -
+           (derivative.GetWeightFunctionSpline()
+                .DerivativeWRTParametricDimension(order_) *
+            derivative.GetNumeratorSpline()))
+              .OrderElevateAlongParametricDimension(i_para_dim),
+          // v^2
+          derivative.GetWeightFunctionSpline() *
+              derivative.GetWeightFunctionSpline());
     }
-    return derivative;
+  }
+  return derivative;
 }
 
 template <std::size_t parametric_dimension, typename PhysicalPointType,

--- a/src/rational_bezier_spline.inc
+++ b/src/rational_bezier_spline.inc
@@ -807,3 +807,78 @@ RationalBezierSpline<parametric_dimension, PhysicalPointType, ScalarType>::
   }
   return return_value;
 }
+
+template <std::size_t parametric_dimension, typename PhysicalPointType,
+          typename ScalarType>
+constexpr bool RationalBezierSpline<parametric_dimension, PhysicalPointType,
+                                    ScalarType>::FitsIntoUnitCube() const {
+  const auto maximum_corner = MaximumCorner();
+  const auto minimum_corner = MinimumCorner();
+  if constexpr (std::is_arithmetic_v<PhysicalPointType>) {
+    if ((maximum_corner > static_cast<ScalarType>(1)) ||
+        (minimum_corner < static_cast<ScalarType>(0))) {
+      return false;
+    }
+  } else {
+    for (IndexingType i_dim{}; i_dim < PhysicalPointType::kSpatialDimension;
+         i_dim++) {
+      if ((maximum_corner[i_dim] > static_cast<ScalarType>(1)) ||
+          (minimum_corner[i_dim] < static_cast<ScalarType>(0))) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+template <std::size_t parametric_dimension, typename PhysicalPointType,
+          typename ScalarType>
+constexpr PhysicalPointType
+RationalBezierSpline<parametric_dimension, PhysicalPointType,
+                     ScalarType>::MinimumCorner() const {
+  if (GetNumberOfControlPoints() == 0) {
+    utils::Logger::TerminatingError(
+        "Spline is non-defined or has no control-points");
+  }
+  PhysicalPointType minimum{ControlPoint(LocalToGlobalIndex(0))};
+  for (IndexingType i{1}; i < GetNumberOfControlPoints(); i++) {
+    if constexpr (std::is_arithmetic_v<PhysicalPointType>) {
+      minimum = std::min(minimum, ControlPoint(LocalToGlobalIndex(i)));
+    } else {
+      const PhysicalPointType& control_point_reference =
+          ControlPoint(LocalToGlobalIndex(i));
+      for (IndexingType i_dim{}; i_dim < PhysicalPointType::kSpatialDimension;
+           i_dim++) {
+        minimum[i_dim] =
+            std::min(minimum[i_dim], control_point_reference[i_dim]);
+      }
+    }
+  }
+  return minimum;
+}
+
+template <std::size_t parametric_dimension, typename PhysicalPointType,
+          typename ScalarType>
+constexpr PhysicalPointType
+RationalBezierSpline<parametric_dimension, PhysicalPointType,
+                     ScalarType>::MaximumCorner() const {
+  if (GetNumberOfControlPoints() == 0) {
+    utils::Logger::TerminatingError(
+        "Spline is non-defined or has no control-points");
+  }
+  PhysicalPointType maximum{ControlPoint(LocalToGlobalIndex(0))};
+  for (IndexingType i{1}; i < GetNumberOfControlPoints(); i++) {
+    if constexpr (std::is_arithmetic_v<PhysicalPointType>) {
+      maximum = std::max(maximum, ControlPoint(LocalToGlobalIndex(i)));
+    } else {
+      const PhysicalPointType& control_point_reference =
+          ControlPoint(LocalToGlobalIndex(i));
+      for (IndexingType i_dim{}; i_dim < PhysicalPointType::kSpatialDimension;
+           i_dim++) {
+        maximum[i_dim] =
+            std::max(maximum[i_dim], control_point_reference[i_dim]);
+      }
+    }
+  }
+  return maximum;
+}

--- a/tests/order_and_derivation/order_and_derivation_test.cpp
+++ b/tests/order_and_derivation/order_and_derivation_test.cpp
@@ -135,7 +135,7 @@ TEST_F(BezierTestingSuite, OrderElevation3) {
 // Derivation Of line with known results
 TEST_F(BezierTestingSuite, Derivation) {
   // Expect equality.
-  EXPECT_EQ(line1.DerivativeWRTParametricDimension(0), line1_deriv);
+  EXPECT_EQ(line1.DerivativeWRTParametricDimension(std::array<std::size_t,1>{1}), line1_deriv);
 }
 
 // Demonstrate the direct evaluation of a derivative
@@ -150,12 +150,10 @@ TEST_F(BezierTestingSuite, DerivativeEvaluation) {
                                                  rand_int(0, 5)};
   const auto random_spline = CreateRandomSpline(degrees);
   auto random_spline_deriv = random_spline;
-  for (std::size_t i_para_dim{}; i_para_dim < 3; i_para_dim++) {
-    for (std::size_t i_deriv{}; i_deriv < derivs[i_para_dim]; i_deriv++) {
-      random_spline_deriv =
-          random_spline_deriv.DerivativeWRTParametricDimension(i_para_dim);
-    }
-  }
+  
+        random_spline_deriv =
+            random_spline_deriv.DerivativeWRTParametricDimension(derivs);
+
   const std::size_t n_tests = 10;
   for (std::size_t i_test{}; i_test < n_tests; i_test++) {
     // Create evaluation points

--- a/tests/order_and_derivation/order_and_derivation_test.cpp
+++ b/tests/order_and_derivation/order_and_derivation_test.cpp
@@ -135,7 +135,13 @@ TEST_F(BezierTestingSuite, OrderElevation3) {
 // Derivation Of line with known results
 TEST_F(BezierTestingSuite, Derivation) {
   // Expect equality.
-  EXPECT_EQ(line1.DerivativeWRTParametricDimension(std::array<std::size_t,1>{1}), line1_deriv);
+  EXPECT_EQ(
+      line1.DerivativeWRTParametricDimension(std::array<std::size_t, 1>{1}),
+      line1_deriv);
+  EXPECT_EQ(
+      line1.OrderElevateAlongParametricDimension(0)
+          .DerivativeWRTParametricDimension(std::array<std::size_t, 1>{1}),
+      line1_deriv.OrderElevateAlongParametricDimension(0));
 }
 
 // Demonstrate the direct evaluation of a derivative
@@ -150,9 +156,9 @@ TEST_F(BezierTestingSuite, DerivativeEvaluation) {
                                                  rand_int(0, 5)};
   const auto random_spline = CreateRandomSpline(degrees);
   auto random_spline_deriv = random_spline;
-  
-        random_spline_deriv =
-            random_spline_deriv.DerivativeWRTParametricDimension(derivs);
+
+  random_spline_deriv =
+      random_spline_deriv.DerivativeWRTParametricDimension(derivs);
 
   const std::size_t n_tests = 10;
   for (std::size_t i_test{}; i_test < n_tests; i_test++) {

--- a/tests/rational_splines/rational_splines_test.cpp
+++ b/tests/rational_splines/rational_splines_test.cpp
@@ -331,7 +331,8 @@ namespace bezman::tests::rational_splines_test
   {
     using RationalBezier = RationalBezierSpline<1, double, double>;
     RationalBezier spline{degree, ctps_deriv_test, weights_deriv_test};
-    const auto derivative = spline.DerivativeWRTParametricDimension(0);
+    const auto derivative =
+        spline.DerivativeWRTParametricDimension(std::array<std::size_t, 1>{1});
     // Sample
     const std::size_t n_sample_points{10};
     for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++)
@@ -353,14 +354,9 @@ namespace bezman::tests::rational_splines_test
           {{2, 0}, {1, 1}, {1, 2}}}[i_test];
       const auto random_spline = CreateRandomSpline(degrees);
       auto random_spline_deriv = random_spline;
-      for (std::size_t i_para_dim{}; i_para_dim < para_dims; i_para_dim++)
-      {
-        for (std::size_t i_deriv{}; i_deriv < derivs[i_para_dim]; i_deriv++)
-        {
-          random_spline_deriv =
-              random_spline_deriv.DerivativeWRTParametricDimension(i_para_dim);
-        }
-      }
+      
+            random_spline_deriv =
+                random_spline_deriv.DerivativeWRTParametricDimension(derivs);
 
       // Evaluate for comparison
       for (std::size_t j_test{}; j_test < n_test_evaluations; j_test++)

--- a/tests/rational_splines/rational_splines_test.cpp
+++ b/tests/rational_splines/rational_splines_test.cpp
@@ -32,661 +32,612 @@ SOFTWARE.
 
 using namespace bezman;
 
-namespace bezman::tests::rational_splines_test
-{
+namespace bezman::tests::rational_splines_test {
 
-  class RationalSplineTestSuite : public ::testing::Test
-  {
-  public:
-    using Point3D = Point<3, double>;
-    using Point2D = Point<2, double>;
-    using Point1D = Point<1, double>;
+class RationalSplineTestSuite : public ::testing::Test {
+ public:
+  using Point3D = Point<3, double>;
+  using Point2D = Point<2, double>;
+  using Point1D = Point<1, double>;
 
-  protected:
-    void SetUp() override {}
+ protected:
+  void SetUp() override {}
 
-    // Provide some data to form splines.
-    std::vector<Point2D> ctps{Point2D{1., 0.}, Point2D{1., 1.}, Point2D{0., 1.}};
-    std::vector<double> weights{1., 1 / std::sqrt(2), 1.};
-    std::vector<Point2D> ctps2{Point2D{0., 0.}, Point2D{0., 1.}, Point2D{1., 1.}};
-    std::vector<double> weights2{1., 1., 1.};
-    std::array<std::size_t, 1> degree{2};
-    std::array<std::size_t, 1> new_degree{3};
+  // Provide some data to form splines.
+  std::vector<Point2D> ctps{Point2D{1., 0.}, Point2D{1., 1.}, Point2D{0., 1.}};
+  std::vector<double> weights{1., 1 / std::sqrt(2), 1.};
+  std::vector<Point2D> ctps2{Point2D{0., 0.}, Point2D{0., 1.}, Point2D{1., 1.}};
+  std::vector<double> weights2{1., 1., 1.};
+  std::array<std::size_t, 1> degree{2};
+  std::array<std::size_t, 1> new_degree{3};
 
-    // Higher Dimensional Examples
-    std::vector<Point2D> ctps_2D{
-        Point2D{1., 0.},
-        Point2D{1., 1.},
-        Point2D{0., 1.},
-        Point2D{2., 0.},
-        Point2D{2., 2.},
-        Point2D{0., 2.},
-    };
-    std::vector<double> weights_2D{1., 1 / std::sqrt(2), 1.,
-                                   1., 1 / std::sqrt(2), 1.};
-    std::vector<Point2D> ctps2_2D{
-        Point2D{0., 0.}, Point2D{1., 0.}, Point2D{2., 0.},
-        Point2D{0., 1.}, Point2D{1., 1.}, Point2D{2., 1.},
-        Point2D{0., 2.}, Point2D{1., 2.}, Point2D{2., 2.}};
-    std::vector<double> weights2_2D{1., 1., 1., 1., 1., 1., 1., 1., 1.};
-    std::array<std::size_t, 2> degrees_2D{2, 1};
-    std::array<std::size_t, 2> degrees2_2D{2, 2};
+  // Higher Dimensional Examples
+  std::vector<Point2D> ctps_2D{
+      Point2D{1., 0.}, Point2D{1., 1.}, Point2D{0., 1.},
+      Point2D{2., 0.}, Point2D{2., 2.}, Point2D{0., 2.},
+  };
+  std::vector<double> weights_2D{1., 1 / std::sqrt(2), 1.,
+                                 1., 1 / std::sqrt(2), 1.};
+  std::vector<Point2D> ctps2_2D{
+      Point2D{0., 0.}, Point2D{1., 0.}, Point2D{2., 0.},
+      Point2D{0., 1.}, Point2D{1., 1.}, Point2D{2., 1.},
+      Point2D{0., 2.}, Point2D{1., 2.}, Point2D{2., 2.}};
+  std::vector<double> weights2_2D{1., 1., 1., 1., 1., 1., 1., 1., 1.};
+  std::array<std::size_t, 2> degrees_2D{2, 1};
+  std::array<std::size_t, 2> degrees2_2D{2, 2};
 
-    // Testing Point
-    Point2D testing_point{2., 2.};
-    double testing_weight{3.};
+  // Testing Point
+  Point2D testing_point{2., 2.};
+  double testing_weight{3.};
 
-    // Testing a derivative with a scalar bezier
-    std::vector<double> ctps_deriv_test{3., 4., 5.};
-    std::vector<double> weights_deriv_test{1., .5, 1.};
+  // Testing a derivative with a scalar bezier
+  std::vector<double> ctps_deriv_test{3., 4., 5.};
+  std::vector<double> weights_deriv_test{1., .5, 1.};
 
-    double AnalyticalSolutionToRspline(const double x)
-    {
-      return (1. + 2. * x - 2 * x * x) / std::pow(1 - x + x * x, 2);
-    }
+  double AnalyticalSolutionToRspline(const double x) {
+    return (1. + 2. * x - 2 * x * x) / std::pow(1 - x + x * x, 2);
+  }
 
-    // Create a randomized spline
-    template <std::size_t para_dim>
-    auto CreateRandomSpline(const std::array<std::size_t, para_dim> &degrees)
-    {
-      RationalBezierSpline<para_dim, Point3D, double> randomSpline{degrees};
-      for (std::size_t i_ctps{}; i_ctps < randomSpline.GetNumberOfControlPoints();
-           i_ctps++)
-      {
-        for (std::size_t i_dim{}; i_dim < 3; i_dim++)
-        {
-          randomSpline.GetWeightedControlPoints()[i_ctps][i_dim] =
-              static_cast<double>(rand()) / static_cast<double>(RAND_MAX);
-        }
-        randomSpline.GetWeights()[i_ctps] =
+  // Create a randomized spline
+  template <std::size_t para_dim>
+  auto CreateRandomSpline(const std::array<std::size_t, para_dim> &degrees) {
+    RationalBezierSpline<para_dim, Point3D, double> randomSpline{degrees};
+    for (std::size_t i_ctps{}; i_ctps < randomSpline.GetNumberOfControlPoints();
+         i_ctps++) {
+      for (std::size_t i_dim{}; i_dim < 3; i_dim++) {
+        randomSpline.GetWeightedControlPoints()[i_ctps][i_dim] =
             static_cast<double>(rand()) / static_cast<double>(RAND_MAX);
       }
-      return randomSpline;
+      randomSpline.GetWeights()[i_ctps] =
+          static_cast<double>(rand()) / static_cast<double>(RAND_MAX);
     }
-  };
+    return randomSpline;
+  }
+};
 
-  // Test Constructors and equal operations
-  TEST_F(RationalSplineTestSuite, Constructors)
-  {
-    using RationalBezier = RationalBezierSpline<1, Point2D, double>;
-    EXPECT_NO_FATAL_FAILURE(RationalBezier());
-    EXPECT_NO_FATAL_FAILURE(RationalBezier{degree});
-    EXPECT_NO_FATAL_FAILURE(RationalBezier(degree, ctps, weights));
+// Test Constructors and equal operations
+TEST_F(RationalSplineTestSuite, Constructors) {
+  using RationalBezier = RationalBezierSpline<1, Point2D, double>;
+  EXPECT_NO_FATAL_FAILURE(RationalBezier());
+  EXPECT_NO_FATAL_FAILURE(RationalBezier{degree});
+  EXPECT_NO_FATAL_FAILURE(RationalBezier(degree, ctps, weights));
+}
+
+// Getters and Setters
+TEST_F(RationalSplineTestSuite, GettersSetters) {
+  using RationalBezier = RationalBezierSpline<1, Point2D, double>;
+  RationalBezier circular_arc(degree, ctps, weights);
+  const RationalBezier kcirular_arc(degree, ctps, weights);
+  std::array<std::size_t, 1> index_a{0};
+
+  // Get Degrees
+  EXPECT_EQ(circular_arc.GetDegrees(), degree);
+
+  // Access Control Points (+ weighted ones) and Weights
+  // Weighted CTPS
+  EXPECT_EQ(circular_arc.WeightedControlPoint(1), ctps[1] * weights[1]);
+  EXPECT_EQ(kcirular_arc.WeightedControlPoint(1), ctps[1] * weights[1]);
+  circular_arc.WeightedControlPoint(1) = testing_point;
+  EXPECT_EQ(circular_arc.WeightedControlPoint(1), testing_point);
+  EXPECT_EQ(circular_arc.WeightedControlPoint(index_a), ctps[0] * weights[0]);
+  EXPECT_EQ(kcirular_arc.WeightedControlPoint(index_a), ctps[0] * weights[0]);
+  circular_arc.WeightedControlPoint(index_a) = testing_point;
+  EXPECT_EQ(circular_arc.WeightedControlPoint(index_a), testing_point);
+
+  circular_arc.WeightedControlPoint(1) = ctps[1] * weights[1];  // Reset arc
+  circular_arc.WeightedControlPoint(index_a) = ctps[0] * weights[0];
+
+  // Weights
+  EXPECT_EQ(circular_arc.Weight(1), weights[1]);
+  EXPECT_EQ(kcirular_arc.Weight(1), weights[1]);
+  circular_arc.Weight(1) = testing_weight;
+  EXPECT_EQ(circular_arc.Weight(1), testing_weight);
+  EXPECT_EQ(circular_arc.Weight(index_a), weights[0]);
+  EXPECT_EQ(kcirular_arc.Weight(index_a), weights[0]);
+  circular_arc.Weight(index_a) = testing_weight;
+  EXPECT_EQ(circular_arc.Weight(index_a), testing_weight);
+
+  circular_arc.Weight(1) = weights[1];
+  circular_arc.Weight(index_a) = weights[0];
+
+  // "clean" CTPS
+  EXPECT_EQ(circular_arc.ControlPoint(1), ctps[1]);
+  EXPECT_EQ(kcirular_arc.ControlPoint(1), ctps[1]);
+  EXPECT_EQ(circular_arc.ControlPoint(index_a), ctps[0]);
+  EXPECT_EQ(kcirular_arc.ControlPoint(index_a), ctps[0]);
+
+  // Update the degrees
+  EXPECT_NO_FATAL_FAILURE(circular_arc.UpdateDegrees(new_degree));
+  EXPECT_EQ(circular_arc.GetDegrees(), new_degree);
+}
+
+TEST_F(RationalSplineTestSuite, Evaluation) {
+  using RationalBezier = RationalBezierSpline<1, Point2D, double>;
+  RationalBezier circular_arc(degree, ctps, weights);
+  Point2D mid_point{std::cos(std::acos(-1) * .25),
+                    std::sin(std::acos(-1) * .25)};
+  EXPECT_FLOAT_EQ(circular_arc.Evaluate(.5)[0], mid_point[0]);
+  EXPECT_FLOAT_EQ(circular_arc.Evaluate(.5)[1], mid_point[1]);
+  // Test if symmetric around the x=y plane
+  double t{0.15};
+  EXPECT_FLOAT_EQ(circular_arc.Evaluate(t)[1],
+                  circular_arc.Evaluate(1. - t)[0]);
+  EXPECT_FLOAT_EQ(circular_arc.Evaluate(t)[0],
+                  circular_arc.Evaluate(1. - t)[1]);
+}
+
+TEST_F(RationalSplineTestSuite, ForwardEvaluation) {
+  using RationalBezier = RationalBezierSpline<1, Point2D, double>;
+  RationalBezier circular_arc(degree, ctps, weights);
+  Point2D mid_point{std::cos(std::acos(-1) * .25),
+                    std::sin(std::acos(-1) * .25)};
+  EXPECT_FLOAT_EQ(circular_arc.Evaluate(.5)[0], mid_point[0]);
+  EXPECT_FLOAT_EQ(circular_arc.Evaluate(.5)[1], mid_point[1]);
+  // Test if symmetric around the x=y plane
+  double t{0.15};
+  EXPECT_FLOAT_EQ(circular_arc.Evaluate(t)[1],
+                  circular_arc.Evaluate(1. - t)[0]);
+  EXPECT_FLOAT_EQ(circular_arc.Evaluate(t)[0],
+                  circular_arc.Evaluate(1. - t)[1]);
+  EXPECT_FLOAT_EQ(circular_arc.ForwardEvaluate(t)[1],
+                  circular_arc.ForwardEvaluate(1. - t)[0]);
+  EXPECT_FLOAT_EQ(circular_arc.ForwardEvaluate(t)[0],
+                  circular_arc.ForwardEvaluate(1. - t)[1]);
+}
+
+// Test Basis Function evaluation
+TEST_F(RationalSplineTestSuite, TestBasisFunctions) {
+  using RationalBezier = RationalBezierSpline<1, Point2D, double>;
+  RationalBezier circular_arc(degree, ctps, weights);
+  // Create random evaluation point
+  const double xx{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+  const Point1D x{xx};
+  // Retrieve basis functions (check overloads)
+  EXPECT_EQ(circular_arc.BasisFunctions(xx), circular_arc.BasisFunctions(x));
+  EXPECT_EQ(circular_arc.BasisFunctionContributions(xx),
+            circular_arc.BasisFunctionContributions(x));
+
+  // Compare to analytical solution
+  double weighted_basis_function_sum{};
+
+  // Test Polynomial Basis Functions
+  const auto basis_functions = circular_arc.BasisFunctionContributions(x);
+  for (std::size_t i_basis{}; i_basis < degree[0] + 1; i_basis++) {
+    const double analytical_solution_bernstein_pol =
+        utils::FastBinomialCoefficient::choose(degree[0], i_basis) *
+        std::pow(x[0], i_basis) * std::pow(1. - x[0], degree[0] - i_basis);
+    weighted_basis_function_sum +=
+        analytical_solution_bernstein_pol * circular_arc.Weight(i_basis);
+    EXPECT_FLOAT_EQ(basis_functions[0][i_basis],
+                    analytical_solution_bernstein_pol);
   }
 
-  // Getters and Setters
-  TEST_F(RationalSplineTestSuite, GettersSetters)
-  {
-    using RationalBezier = RationalBezierSpline<1, Point2D, double>;
-    RationalBezier circular_arc(degree, ctps, weights);
-    const RationalBezier kcirular_arc(degree, ctps, weights);
-    std::array<std::size_t, 1> index_a{0};
+  // Test Weighted Basis Functions
+  const auto weighted_basis_function = circular_arc.BasisFunctions(xx);
+  const auto non_weighted_basis_function =
+      circular_arc.UnweightedBasisFunctions(xx);
 
-    // Get Degrees
-    EXPECT_EQ(circular_arc.GetDegrees(), degree);
-
-    // Access Control Points (+ weighted ones) and Weights
-    // Weighted CTPS
-    EXPECT_EQ(circular_arc.WeightedControlPoint(1), ctps[1] * weights[1]);
-    EXPECT_EQ(kcirular_arc.WeightedControlPoint(1), ctps[1] * weights[1]);
-    circular_arc.WeightedControlPoint(1) = testing_point;
-    EXPECT_EQ(circular_arc.WeightedControlPoint(1), testing_point);
-    EXPECT_EQ(circular_arc.WeightedControlPoint(index_a), ctps[0] * weights[0]);
-    EXPECT_EQ(kcirular_arc.WeightedControlPoint(index_a), ctps[0] * weights[0]);
-    circular_arc.WeightedControlPoint(index_a) = testing_point;
-    EXPECT_EQ(circular_arc.WeightedControlPoint(index_a), testing_point);
-
-    circular_arc.WeightedControlPoint(1) = ctps[1] * weights[1]; // Reset arc
-    circular_arc.WeightedControlPoint(index_a) = ctps[0] * weights[0];
-
-    // Weights
-    EXPECT_EQ(circular_arc.Weight(1), weights[1]);
-    EXPECT_EQ(kcirular_arc.Weight(1), weights[1]);
-    circular_arc.Weight(1) = testing_weight;
-    EXPECT_EQ(circular_arc.Weight(1), testing_weight);
-    EXPECT_EQ(circular_arc.Weight(index_a), weights[0]);
-    EXPECT_EQ(kcirular_arc.Weight(index_a), weights[0]);
-    circular_arc.Weight(index_a) = testing_weight;
-    EXPECT_EQ(circular_arc.Weight(index_a), testing_weight);
-
-    circular_arc.Weight(1) = weights[1];
-    circular_arc.Weight(index_a) = weights[0];
-
-    // "clean" CTPS
-    EXPECT_EQ(circular_arc.ControlPoint(1), ctps[1]);
-    EXPECT_EQ(kcirular_arc.ControlPoint(1), ctps[1]);
-    EXPECT_EQ(circular_arc.ControlPoint(index_a), ctps[0]);
-    EXPECT_EQ(kcirular_arc.ControlPoint(index_a), ctps[0]);
-
-    // Update the degrees
-    EXPECT_NO_FATAL_FAILURE(circular_arc.UpdateDegrees(new_degree));
-    EXPECT_EQ(circular_arc.GetDegrees(), new_degree);
+  for (std::size_t i_basis{}; i_basis < degree[0] + 1; i_basis++) {
+    const double analytical_solution_bernstein_pol =
+        utils::FastBinomialCoefficient::choose(degree[0], i_basis) *
+        std::pow(x[0], i_basis) * std::pow(1. - x[0], degree[0] - i_basis);
+    EXPECT_DOUBLE_EQ(weighted_basis_function[i_basis],
+                     analytical_solution_bernstein_pol *
+                         circular_arc.GetWeights()[i_basis] /
+                         weighted_basis_function_sum);
+    EXPECT_DOUBLE_EQ(
+        non_weighted_basis_function[i_basis],
+        analytical_solution_bernstein_pol / weighted_basis_function_sum);
   }
+}
 
-  TEST_F(RationalSplineTestSuite, Evaluation)
-  {
-    using RationalBezier = RationalBezierSpline<1, Point2D, double>;
-    RationalBezier circular_arc(degree, ctps, weights);
-    Point2D mid_point{std::cos(std::acos(-1) * .25),
-                      std::sin(std::acos(-1) * .25)};
-    EXPECT_FLOAT_EQ(circular_arc.Evaluate(.5)[0], mid_point[0]);
-    EXPECT_FLOAT_EQ(circular_arc.Evaluate(.5)[1], mid_point[1]);
-    // Test if symmetric around the x=y plane
-    double t{0.15};
-    EXPECT_FLOAT_EQ(circular_arc.Evaluate(t)[1],
-                    circular_arc.Evaluate(1. - t)[0]);
-    EXPECT_FLOAT_EQ(circular_arc.Evaluate(t)[0],
-                    circular_arc.Evaluate(1. - t)[1]);
-  }
+// Test High Dimensional Evaluation
+TEST_F(RationalSplineTestSuite, HighDimEvaluation) {
+  using RationalBezierSurface = RationalBezierSpline<2, Point2D, double>;
+  RationalBezierSurface circle_segment{degrees_2D, ctps_2D, weights_2D};
+  // Evaluate
+  Point2D mid_point{std::cos(std::acos(-1) * .25) * 1.5,
+                    std::sin(std::acos(-1) * .25) * 1.5};
+  EXPECT_FLOAT_EQ(circle_segment.Evaluate(.5, .5)[0], mid_point[0]);
+  EXPECT_FLOAT_EQ(circle_segment.Evaluate(.5, .5)[1], mid_point[1]);
 
-  TEST_F(RationalSplineTestSuite, ForwardEvaluation)
-  {
-    using RationalBezier = RationalBezierSpline<1, Point2D, double>;
-    RationalBezier circular_arc(degree, ctps, weights);
-    Point2D mid_point{std::cos(std::acos(-1) * .25),
-                      std::sin(std::acos(-1) * .25)};
-    EXPECT_FLOAT_EQ(circular_arc.Evaluate(.5)[0], mid_point[0]);
-    EXPECT_FLOAT_EQ(circular_arc.Evaluate(.5)[1], mid_point[1]);
-    // Test if symmetric around the x=y plane
-    double t{0.15};
-    EXPECT_FLOAT_EQ(circular_arc.Evaluate(t)[1],
-                    circular_arc.Evaluate(1. - t)[0]);
-    EXPECT_FLOAT_EQ(circular_arc.Evaluate(t)[0],
-                    circular_arc.Evaluate(1. - t)[1]);
-    EXPECT_FLOAT_EQ(circular_arc.ForwardEvaluate(t)[1],
-                    circular_arc.ForwardEvaluate(1. - t)[0]);
-    EXPECT_FLOAT_EQ(circular_arc.ForwardEvaluate(t)[0],
-                    circular_arc.ForwardEvaluate(1. - t)[1]);
-  }
+  // Test Basis Functions
+  RationalBezierSurface pseudo_polynomial_rectangle{degrees2_2D, ctps2_2D,
+                                                    weights2_2D};
+  const auto degrees = pseudo_polynomial_rectangle.GetDegrees();
+  // Create random evaluation point
+  const double xx{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+  const double xy{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+  const Point2D x{xx, xy};
+  // Retrieve basis functions
+  const auto basis_functions =
+      pseudo_polynomial_rectangle.BasisFunctions(xx, xy);
+  const auto pol_basis_functions =
+      pseudo_polynomial_rectangle.BasisFunctions(xx, xy);
 
-  // Test Basis Function evaluation
-  TEST_F(RationalSplineTestSuite, TestBasisFunctions)
-  {
-    using RationalBezier = RationalBezierSpline<1, Point2D, double>;
-    RationalBezier circular_arc(degree, ctps, weights);
-    // Create random evaluation point
-    const double xx{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
-    const Point1D x{xx};
-    // Retrieve basis functions (check overloads)
-    EXPECT_EQ(circular_arc.BasisFunctions(xx), circular_arc.BasisFunctions(x));
-    EXPECT_EQ(circular_arc.BasisFunctionContributions(xx),
-              circular_arc.BasisFunctionContributions(x));
-
-    // Compare to analytical solution
-    double weighted_basis_function_sum{};
-
-    // Test Polynomial Basis Functions
-    const auto basis_functions = circular_arc.BasisFunctionContributions(x);
-    for (std::size_t i_basis{}; i_basis < degree[0] + 1; i_basis++)
-    {
-      const double analytical_solution_bernstein_pol =
-          utils::FastBinomialCoefficient::choose(degree[0], i_basis) *
-          std::pow(x[0], i_basis) * std::pow(1. - x[0], degree[0] - i_basis);
-      weighted_basis_function_sum +=
-          analytical_solution_bernstein_pol * circular_arc.Weight(i_basis);
-      EXPECT_FLOAT_EQ(basis_functions[0][i_basis],
-                      analytical_solution_bernstein_pol);
-    }
-
-    // Test Weighted Basis Functions
-    const auto weighted_basis_function = circular_arc.BasisFunctions(xx);
-    const auto non_weighted_basis_function =
-        circular_arc.UnweightedBasisFunctions(xx);
-
-    for (std::size_t i_basis{}; i_basis < degree[0] + 1; i_basis++)
-    {
-      const double analytical_solution_bernstein_pol =
-          utils::FastBinomialCoefficient::choose(degree[0], i_basis) *
-          std::pow(x[0], i_basis) * std::pow(1. - x[0], degree[0] - i_basis);
-      EXPECT_DOUBLE_EQ(weighted_basis_function[i_basis],
-                       analytical_solution_bernstein_pol *
-                           circular_arc.GetWeights()[i_basis] /
-                           weighted_basis_function_sum);
-      EXPECT_DOUBLE_EQ(
-          non_weighted_basis_function[i_basis],
-          analytical_solution_bernstein_pol / weighted_basis_function_sum);
-    }
-  }
-
-  // Test High Dimensional Evaluation
-  TEST_F(RationalSplineTestSuite, HighDimEvaluation)
-  {
-    using RationalBezierSurface = RationalBezierSpline<2, Point2D, double>;
-    RationalBezierSurface circle_segment{degrees_2D, ctps_2D, weights_2D};
-    // Evaluate
-    Point2D mid_point{std::cos(std::acos(-1) * .25) * 1.5,
-                      std::sin(std::acos(-1) * .25) * 1.5};
-    EXPECT_FLOAT_EQ(circle_segment.Evaluate(.5, .5)[0], mid_point[0]);
-    EXPECT_FLOAT_EQ(circle_segment.Evaluate(.5, .5)[1], mid_point[1]);
-
-    // Test Basis Functions
-    RationalBezierSurface pseudo_polynomial_rectangle{degrees2_2D, ctps2_2D,
-                                                      weights2_2D};
-    const auto degrees = pseudo_polynomial_rectangle.GetDegrees();
-    // Create random evaluation point
-    const double xx{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
-    const double xy{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
-    const Point2D x{xx, xy};
-    // Retrieve basis functions
-    const auto basis_functions =
-        pseudo_polynomial_rectangle.BasisFunctions(xx, xy);
-    const auto pol_basis_functions =
-        pseudo_polynomial_rectangle.BasisFunctions(xx, xy);
-
-    // Compare to analytical solution
-    for (std::size_t pdim{}; pdim < 2; pdim++)
-    {
-      for (std::size_t i_basis{}; i_basis < degrees[pdim] + 1; i_basis++)
-      {
-        EXPECT_FLOAT_EQ(basis_functions[i_basis], pol_basis_functions[i_basis]);
-      }
+  // Compare to analytical solution
+  for (std::size_t pdim{}; pdim < 2; pdim++) {
+    for (std::size_t i_basis{}; i_basis < degrees[pdim] + 1; i_basis++) {
+      EXPECT_FLOAT_EQ(basis_functions[i_basis], pol_basis_functions[i_basis]);
     }
   }
+}
 
-  // Test Refinement
-  TEST_F(RationalSplineTestSuite, RefinementTest)
-  {
-    using RationalBezierSurface = RationalBezierSpline<2, Point2D, double>;
-    RationalBezierSurface circle_segment{degrees_2D, ctps_2D, weights_2D};
-    using RationalBezier = RationalBezierSpline<1, Point2D, double>;
-    RationalBezier circular_arc(degree, ctps, weights);
-    const RationalBezierSurface kcircle_segment{degrees_2D, ctps_2D, weights_2D};
-    const RationalBezier kcircular_arc(degree, ctps, weights);
+// Test Refinement
+TEST_F(RationalSplineTestSuite, RefinementTest) {
+  using RationalBezierSurface = RationalBezierSpline<2, Point2D, double>;
+  RationalBezierSurface circle_segment{degrees_2D, ctps_2D, weights_2D};
+  using RationalBezier = RationalBezierSpline<1, Point2D, double>;
+  RationalBezier circular_arc(degree, ctps, weights);
+  const RationalBezierSurface kcircle_segment{degrees_2D, ctps_2D, weights_2D};
+  const RationalBezier kcircular_arc(degree, ctps, weights);
 
-    // Test specification
-    const std::size_t n_refinement_level{3};
-    const std::size_t n_sample_points{10};
+  // Test specification
+  const std::size_t n_refinement_level{3};
+  const std::size_t n_sample_points{10};
 
-    // Refinement
-    for (std::size_t i_refinement{0}; i_refinement < n_refinement_level;
-         i_refinement++)
-    {
-      circle_segment.OrderElevateAlongParametricDimension(0);
-      circle_segment.OrderElevateAlongParametricDimension(1);
-      circular_arc.OrderElevateAlongParametricDimension(0);
-    }
+  // Refinement
+  for (std::size_t i_refinement{0}; i_refinement < n_refinement_level;
+       i_refinement++) {
+    circle_segment.OrderElevateAlongParametricDimension(0);
+    circle_segment.OrderElevateAlongParametricDimension(1);
+    circular_arc.OrderElevateAlongParametricDimension(0);
+  }
 
-    // Sampling
-    for (std::size_t i_sample_x{0}; i_sample_x < n_sample_points; i_sample_x++)
-    {
-      const double xx{static_cast<double>(rand()) /
+  // Sampling
+  for (std::size_t i_sample_x{0}; i_sample_x < n_sample_points; i_sample_x++) {
+    const double xx{static_cast<double>(rand()) /
+                    static_cast<double>(RAND_MAX)};
+    EXPECT_FLOAT_EQ(circular_arc.Evaluate(xx)[0],
+                    kcircular_arc.Evaluate(xx)[0]);
+    for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points;
+         i_sample_y++) {
+      const double xy{static_cast<double>(rand()) /
                       static_cast<double>(RAND_MAX)};
-      EXPECT_FLOAT_EQ(circular_arc.Evaluate(xx)[0],
-                      kcircular_arc.Evaluate(xx)[0]);
-      for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points;
-           i_sample_y++)
-      {
-        const double xy{static_cast<double>(rand()) /
+      EXPECT_FLOAT_EQ(circle_segment.Evaluate(xx, xy)[0],
+                      kcircle_segment.Evaluate(xx, xy)[0]);
+      EXPECT_FLOAT_EQ(circle_segment.Evaluate(xx, xy)[1],
+                      kcircle_segment.Evaluate(xx, xy)[1]);
+    }
+  }
+}
+
+// Test Derivatives of rational Beziers
+TEST_F(RationalSplineTestSuite, DerivativeTesting) {
+  using RationalBezier = RationalBezierSpline<1, double, double>;
+  RationalBezier spline{degree, ctps_deriv_test, weights_deriv_test};
+  const auto derivative =
+      spline.DerivativeWRTParametricDimension(std::array<std::size_t, 1>{1});
+  // Sample
+  const std::size_t n_sample_points{10};
+  for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++) {
+    const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+    EXPECT_FLOAT_EQ(derivative.Evaluate(x), AnalyticalSolutionToRspline(x));
+  }
+}
+
+// Test Derivatives of rational Beziers
+TEST_F(RationalSplineTestSuite, DerivativeEvaluation) {
+  constexpr std::size_t n_tests{3}, para_dims{2};
+  const std::size_t n_test_evaluations{5};
+  for (std::size_t i_test{}; i_test < n_tests; i_test++) {
+    const auto degrees = std::array<std::size_t, para_dims>{3, 3};
+    const auto derivs = std::array<std::array<std::size_t, para_dims>, n_tests>{
+        {{2, 0}, {1, 1}, {1, 2}}}[i_test];
+    const auto random_spline = CreateRandomSpline(degrees);
+    auto random_spline_deriv = random_spline;
+
+    random_spline_deriv =
+        random_spline_deriv.DerivativeWRTParametricDimension(derivs);
+
+    // Evaluate for comparison
+    for (std::size_t j_test{}; j_test < n_test_evaluations; j_test++) {
+      // Create evaluation points
+      const double x{static_cast<double>(rand()) /
+                     static_cast<double>(RAND_MAX)};
+      const double y{static_cast<double>(rand()) /
+                     static_cast<double>(RAND_MAX)};
+      Point2D eval_point{x, y};
+      const auto result = random_spline.EvaluateDerivative(
+          // Evaluation Point
+          eval_point,
+          // derivatives
+          derivs);
+      const auto result_2 = random_spline_deriv.Evaluate(eval_point);
+      // Compare results dimensions
+      for (std::size_t i_dim{}; i_dim < 3; i_dim++) {
+        EXPECT_FLOAT_EQ(result[i_dim], result_2[i_dim]);
+      }
+    }
+  }
+}
+
+// Test Derivatives of rational Beziers
+TEST_F(RationalSplineTestSuite, BasisFunctionDerivativeEvaluation) {
+  constexpr std::size_t n_tests{4}, para_dims{2};
+  const std::size_t n_test_evaluations{5};
+  for (std::size_t i_test{}; i_test < n_tests; i_test++) {
+    const auto degrees = std::array<std::size_t, para_dims>{3, 3};
+    const auto derivs = std::array<std::array<std::size_t, para_dims>, n_tests>{
+        {{2, 0}, {1, 1}, {1, 2}, {1, 3}}}[i_test];
+    const auto random_spline = CreateRandomSpline(degrees);
+
+    // Evaluate for comparison
+    for (std::size_t j_test{}; j_test < n_test_evaluations; j_test++) {
+      // Create evaluation points
+      const double x{static_cast<double>(rand()) /
+                     static_cast<double>(RAND_MAX)};
+      const double y{static_cast<double>(rand()) /
+                     static_cast<double>(RAND_MAX)};
+      Point2D eval_point{x, y};
+      const auto result = random_spline.EvaluateDerivative(
+          // Evaluation Point
+          eval_point,
+          // derivatives
+          derivs);
+      const auto basis_function_derivatives =
+          random_spline.BasisFunctionsDerivatives(
+              // Evaluation Point
+              eval_point,
+              // derivatives
+              derivs);
+      Point3D sum{};
+      for (std::size_t i_basis{};
+           i_basis < random_spline.GetNumberOfControlPoints(); i_basis++) {
+        sum += basis_function_derivatives[i_basis] *
+               random_spline.GetWeightedControlPoints()[i_basis] /
+               random_spline.GetWeights()[i_basis];
+      };
+      // Compare results dimensions
+      for (std::size_t i_dim{}; i_dim < 3; i_dim++) {
+        EXPECT_FLOAT_EQ(result[i_dim], sum[i_dim]);
+      }
+    }
+  }
+}
+
+// Test Multiplication
+TEST_F(RationalSplineTestSuite, MultiplicationTest) {
+  using RationalBezier = RationalBezierSpline<1, Point2D, double>;
+  const RationalBezier circular_arc(degree, ctps, weights);
+  RationalBezier circular_arc_v(degree, ctps, weights);
+  // Create random evaluation point
+  const std::size_t n_sample_points{10};
+
+  const double scalar_v{static_cast<double>(rand()) /
                         static_cast<double>(RAND_MAX)};
-        EXPECT_FLOAT_EQ(circle_segment.Evaluate(xx, xy)[0],
-                        kcircle_segment.Evaluate(xx, xy)[0]);
-        EXPECT_FLOAT_EQ(circle_segment.Evaluate(xx, xy)[1],
-                        kcircle_segment.Evaluate(xx, xy)[1]);
-      }
-    }
+  circular_arc_v *= scalar_v;
+  const auto circular_multiplied = circular_arc * scalar_v;
+
+  for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++) {
+    const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+    EXPECT_FLOAT_EQ(circular_multiplied.Evaluate(x)[0],
+                    circular_arc.Evaluate(x)[0] * scalar_v);
+    EXPECT_FLOAT_EQ(circular_multiplied.Evaluate(x)[1],
+                    circular_arc.Evaluate(x)[1] * scalar_v);
+    EXPECT_FLOAT_EQ(circular_multiplied.Evaluate(x)[0],
+                    circular_arc_v.Evaluate(x)[0]);
+    EXPECT_FLOAT_EQ(circular_multiplied.Evaluate(x)[1],
+                    circular_arc_v.Evaluate(x)[1]);
   }
+}
 
-  // Test Derivatives of rational Beziers
-  TEST_F(RationalSplineTestSuite, DerivativeTesting)
-  {
-    using RationalBezier = RationalBezierSpline<1, double, double>;
-    RationalBezier spline{degree, ctps_deriv_test, weights_deriv_test};
-    const auto derivative =
-        spline.DerivativeWRTParametricDimension(std::array<std::size_t, 1>{1});
-    // Sample
-    const std::size_t n_sample_points{10};
-    for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++)
-    {
-      const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
-      EXPECT_FLOAT_EQ(derivative.Evaluate(x), AnalyticalSolutionToRspline(x));
-    }
+// Test Addition
+TEST_F(RationalSplineTestSuite, AdditionTest) {
+  using RationalBezier = RationalBezierSpline<1, Point2D, double>;
+  const RationalBezier circular_arc(degree, ctps, weights);
+  RationalBezier circular_arc_v(degree, ctps, weights);
+  // Create random evaluation point
+  const std::size_t n_sample_points{10};
+
+  const Point2D shifting_vector{
+      static_cast<double>(rand()) / static_cast<double>(RAND_MAX),
+      static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+
+  circular_arc_v += shifting_vector;
+  const auto circular_modified = circular_arc + shifting_vector;
+
+  for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++) {
+    const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+    EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[0],
+                    circular_arc.Evaluate(x)[0] + shifting_vector[0]);
+    EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[1],
+                    circular_arc.Evaluate(x)[1] + shifting_vector[1]);
+    EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[0],
+                    circular_arc_v.Evaluate(x)[0]);
+    EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[1],
+                    circular_arc_v.Evaluate(x)[1]);
   }
+}
 
-  // Test Derivatives of rational Beziers
-  TEST_F(RationalSplineTestSuite, DerivativeEvaluation)
-  {
-    constexpr std::size_t n_tests{3}, para_dims{2};
-    const std::size_t n_test_evaluations{5};
-    for (std::size_t i_test{}; i_test < n_tests; i_test++)
-    {
-      const auto degrees = std::array<std::size_t, para_dims>{3, 3};
-      const auto derivs = std::array<std::array<std::size_t, para_dims>, n_tests>{
-          {{2, 0}, {1, 1}, {1, 2}}}[i_test];
-      const auto random_spline = CreateRandomSpline(degrees);
-      auto random_spline_deriv = random_spline;
-      
-            random_spline_deriv =
-                random_spline_deriv.DerivativeWRTParametricDimension(derivs);
+// Test Substraction
+TEST_F(RationalSplineTestSuite, Substraction) {
+  using RationalBezier = RationalBezierSpline<1, Point2D, double>;
+  const RationalBezier circular_arc(degree, ctps, weights);
+  RationalBezier circular_arc_v(degree, ctps, weights);
+  // Create random evaluation point
+  const std::size_t n_sample_points{10};
 
-      // Evaluate for comparison
-      for (std::size_t j_test{}; j_test < n_test_evaluations; j_test++)
-      {
-        // Create evaluation points
-        const double x{static_cast<double>(rand()) /
-                       static_cast<double>(RAND_MAX)};
-        const double y{static_cast<double>(rand()) /
-                       static_cast<double>(RAND_MAX)};
-        Point2D eval_point{x, y};
-        const auto result = random_spline.EvaluateDerivative(
-            // Evaluation Point
-            eval_point,
-            // derivatives
-            derivs);
-        const auto result_2 = random_spline_deriv.Evaluate(eval_point);
-        // Compare results dimensions
-        for (std::size_t i_dim{}; i_dim < 3; i_dim++)
-        {
-          EXPECT_FLOAT_EQ(result[i_dim], result_2[i_dim]);
-        }
-      }
-    }
+  const Point2D shifting_vector{
+      static_cast<double>(rand()) / static_cast<double>(RAND_MAX),
+      static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+
+  circular_arc_v -= shifting_vector;
+  const auto circular_modified = circular_arc - shifting_vector;
+  const auto inverted_spline = -circular_arc;
+
+  for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++) {
+    const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+    EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[0],
+                    circular_arc.Evaluate(x)[0] - shifting_vector[0]);
+    EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[1],
+                    circular_arc.Evaluate(x)[1] - shifting_vector[1]);
+    EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[0],
+                    circular_arc_v.Evaluate(x)[0]);
+    EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[1],
+                    circular_arc_v.Evaluate(x)[1]);
+    EXPECT_FLOAT_EQ(inverted_spline.Evaluate(x)[0],
+                    -circular_arc.Evaluate(x)[0]);
+    EXPECT_FLOAT_EQ(inverted_spline.Evaluate(x)[1],
+                    -circular_arc.Evaluate(x)[1]);
   }
+}
 
-  // Test Derivatives of rational Beziers
-  TEST_F(RationalSplineTestSuite, BasisFunctionDerivativeEvaluation)
-  {
-    constexpr std::size_t n_tests{4}, para_dims{2};
-    const std::size_t n_test_evaluations{5};
-    for (std::size_t i_test{}; i_test < n_tests; i_test++)
-    {
-      const auto degrees = std::array<std::size_t, para_dims>{3, 3};
-      const auto derivs = std::array<std::array<std::size_t, para_dims>, n_tests>{{{2, 0}, {1, 1}, {1, 2}, {1, 3}}}[i_test];
-      const auto random_spline = CreateRandomSpline(degrees);
+// Test Addition
+TEST_F(RationalSplineTestSuite, SplineAdditionTest) {
+  using RationalBezier = RationalBezierSpline<1, Point2D, double>;
+  const RationalBezier circular_arc(degree, ctps, weights);
+  RationalBezier circular_arc_v(degree, ctps, weights);
+  const RationalBezier secondary_spline{degree, ctps2, weights2};
 
-      // Evaluate for comparison
-      for (std::size_t j_test{}; j_test < n_test_evaluations; j_test++)
-      {
-        // Create evaluation points
-        const double x{static_cast<double>(rand()) /
-                       static_cast<double>(RAND_MAX)};
-        const double y{static_cast<double>(rand()) /
-                       static_cast<double>(RAND_MAX)};
-        Point2D eval_point{x, y};
-        const auto result = random_spline.EvaluateDerivative(
-            // Evaluation Point
-            eval_point,
-            // derivatives
-            derivs);
-        const auto basis_function_derivatives =
-            random_spline.BasisFunctionsDerivatives(
-                // Evaluation Point
-                eval_point,
-                // derivatives
-                derivs);
-        Point3D sum{};
-        for (std::size_t i_basis{};
-             i_basis < random_spline.GetNumberOfControlPoints(); i_basis++)
-        {
-          sum += basis_function_derivatives[i_basis] *
-                 random_spline.GetWeightedControlPoints()[i_basis] /
-                 random_spline.GetWeights()[i_basis];
-        };
-        // Compare results dimensions
-        for (std::size_t i_dim{}; i_dim < 3; i_dim++)
-        {
-          EXPECT_FLOAT_EQ(result[i_dim], sum[i_dim]);
-        }
-      }
-    }
+  // Create random evaluation point
+  const std::size_t n_sample_points{10};
+
+  // Adding Splines with the same weights does not elevate degree
+  EXPECT_EQ((circular_arc + circular_arc).GetDegrees(),
+            circular_arc.GetDegrees());
+
+  circular_arc_v += secondary_spline;
+  const auto circular_modified = circular_arc + secondary_spline;
+
+  for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++) {
+    const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+    EXPECT_FLOAT_EQ(
+        circular_modified.Evaluate(x)[0],
+        circular_arc.Evaluate(x)[0] + secondary_spline.Evaluate(x)[0]);
+    EXPECT_FLOAT_EQ(
+        circular_modified.Evaluate(x)[1],
+        circular_arc.Evaluate(x)[1] + secondary_spline.Evaluate(x)[1]);
+    EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[0],
+                    circular_arc_v.Evaluate(x)[0]);
+    EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[1],
+                    circular_arc_v.Evaluate(x)[1]);
   }
+}
 
-  // Test Multiplication
-  TEST_F(RationalSplineTestSuite, MultiplicationTest)
-  {
-    using RationalBezier = RationalBezierSpline<1, Point2D, double>;
-    const RationalBezier circular_arc(degree, ctps, weights);
-    RationalBezier circular_arc_v(degree, ctps, weights);
-    // Create random evaluation point
-    const std::size_t n_sample_points{10};
+// Test Substraction of Splines
+TEST_F(RationalSplineTestSuite, SplineSubstractionTest) {
+  using RationalBezier = RationalBezierSpline<1, Point2D, double>;
+  const RationalBezier circular_arc(degree, ctps, weights);
+  RationalBezier circular_arc_v(degree, ctps, weights);
+  const RationalBezier secondary_spline{degree, ctps2, weights2};
 
-    const double scalar_v{static_cast<double>(rand()) /
-                          static_cast<double>(RAND_MAX)};
-    circular_arc_v *= scalar_v;
-    const auto circular_multiplied = circular_arc * scalar_v;
+  // Create random evaluation point
+  const std::size_t n_sample_points{10};
 
-    for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++)
-    {
-      const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
-      EXPECT_FLOAT_EQ(circular_multiplied.Evaluate(x)[0],
-                      circular_arc.Evaluate(x)[0] * scalar_v);
-      EXPECT_FLOAT_EQ(circular_multiplied.Evaluate(x)[1],
-                      circular_arc.Evaluate(x)[1] * scalar_v);
-      EXPECT_FLOAT_EQ(circular_multiplied.Evaluate(x)[0],
-                      circular_arc_v.Evaluate(x)[0]);
-      EXPECT_FLOAT_EQ(circular_multiplied.Evaluate(x)[1],
-                      circular_arc_v.Evaluate(x)[1]);
-    }
+  // Adding Splines with the same weights does not elevate degree
+  EXPECT_EQ((circular_arc - circular_arc).GetDegrees(),
+            circular_arc.GetDegrees());
+
+  circular_arc_v -= secondary_spline;
+  const auto circular_modified = circular_arc - secondary_spline;
+
+  for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++) {
+    const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+    EXPECT_FLOAT_EQ(
+        circular_modified.Evaluate(x)[0],
+        circular_arc.Evaluate(x)[0] - secondary_spline.Evaluate(x)[0]);
+    EXPECT_FLOAT_EQ(
+        circular_modified.Evaluate(x)[1],
+        circular_arc.Evaluate(x)[1] - secondary_spline.Evaluate(x)[1]);
+    EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[0],
+                    circular_arc_v.Evaluate(x)[0]);
+    EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[1],
+                    circular_arc_v.Evaluate(x)[1]);
   }
+}
 
-  // Test Addition
-  TEST_F(RationalSplineTestSuite, AdditionTest)
-  {
-    using RationalBezier = RationalBezierSpline<1, Point2D, double>;
-    const RationalBezier circular_arc(degree, ctps, weights);
-    RationalBezier circular_arc_v(degree, ctps, weights);
-    // Create random evaluation point
-    const std::size_t n_sample_points{10};
+// Test Multiplication of Splines
+TEST_F(RationalSplineTestSuite, SplineMultiplicationTest) {
+  using RationalBezier = RationalBezierSpline<1, Point2D, double>;
+  const RationalBezier circular_arc(degree, ctps, weights);
+  const RationalBezier secondary_spline{degree, ctps2, weights2};
 
-    const Point2D shifting_vector{
-        static_cast<double>(rand()) / static_cast<double>(RAND_MAX),
-        static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+  // Create random evaluation point
+  const std::size_t n_sample_points{10};
 
-    circular_arc_v += shifting_vector;
-    const auto circular_modified = circular_arc + shifting_vector;
+  const auto circular_modified = circular_arc * secondary_spline;
 
-    for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++)
-    {
-      const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
-      EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[0],
-                      circular_arc.Evaluate(x)[0] + shifting_vector[0]);
-      EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[1],
-                      circular_arc.Evaluate(x)[1] + shifting_vector[1]);
-      EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[0],
-                      circular_arc_v.Evaluate(x)[0]);
-      EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[1],
-                      circular_arc_v.Evaluate(x)[1]);
-    }
+  for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++) {
+    const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+    EXPECT_FLOAT_EQ(circular_modified.Evaluate(x),
+                    circular_arc.Evaluate(x) * secondary_spline.Evaluate(x));
   }
+}
 
-  // Test Substraction
-  TEST_F(RationalSplineTestSuite, Substraction)
-  {
-    using RationalBezier = RationalBezierSpline<1, Point2D, double>;
-    const RationalBezier circular_arc(degree, ctps, weights);
-    RationalBezier circular_arc_v(degree, ctps, weights);
-    // Create random evaluation point
-    const std::size_t n_sample_points{10};
+// Test Unit Cube Checks
+TEST_F(RationalSplineTestSuite, CubeCheckSplineTest) {
+  using RationalBezierSurface = RationalBezierSpline<2, Point2D, double>;
+  const RationalBezierSurface circle_segment{degrees_2D, ctps_2D, weights_2D};
+  using RationalBezier = RationalBezierSpline<1, Point2D, double>;
+  const RationalBezier circular_arc(degree, ctps, weights);
+  EXPECT_FLOAT_EQ(circle_segment.MaximumCorner()[0], Point2D(2., 2.)[0]);
+  EXPECT_FLOAT_EQ(circle_segment.MaximumCorner()[1], Point2D(2., 2.)[1]);
+  EXPECT_FLOAT_EQ(circle_segment.MinimumCorner()[0], Point2D(0., 0.)[0]);
+  EXPECT_FLOAT_EQ(circle_segment.MinimumCorner()[1], Point2D(0., 0.)[1]);
+  EXPECT_FALSE(circle_segment.FitsIntoUnitCube());
+  EXPECT_TRUE(circular_arc.FitsIntoUnitCube());
+}
 
-    const Point2D shifting_vector{
-        static_cast<double>(rand()) / static_cast<double>(RAND_MAX),
-        static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+// Test Composition of (Rational) splines
+TEST_F(RationalSplineTestSuite, SplineComposition) {
+  using RationalBezierSurface = RationalBezierSpline<2, Point2D, double>;
+  RationalBezierSurface circle_segment_large =
+      RationalBezierSurface(degrees_2D, ctps_2D, weights_2D);
+  RationalBezierSurface circle_segment_small = circle_segment_large * 0.5;
+  using RationalBezier = RationalBezierSpline<1, Point2D, double>;
+  using BezierSurface = BezierSpline<2, Point2D, double>;
+  const RationalBezier circular_arc(degree, ctps, weights);
+  const BezierSurface rectangle{
+      // degrees
+      std::array<std::size_t, 2>{1, 1},
+      // CTPS
+      std::vector<Point2D>{Point2D{0.5, 0.}, Point2D{1., 0.3}, Point2D{0., 0.3},
+                           Point2D{0.5, 1.}}};
 
-    circular_arc_v -= shifting_vector;
-    const auto circular_modified = circular_arc - shifting_vector;
-    const auto inverted_spline = -circular_arc;
+  // Create random evaluation point
+  const std::size_t n_sample_points{5};
 
-    for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++)
-    {
-      const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
-      EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[0],
-                      circular_arc.Evaluate(x)[0] - shifting_vector[0]);
-      EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[1],
-                      circular_arc.Evaluate(x)[1] - shifting_vector[1]);
-      EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[0],
-                      circular_arc_v.Evaluate(x)[0]);
-      EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[1],
-                      circular_arc_v.Evaluate(x)[1]);
-      EXPECT_FLOAT_EQ(inverted_spline.Evaluate(x)[0],
-                      -circular_arc.Evaluate(x)[0]);
-      EXPECT_FLOAT_EQ(inverted_spline.Evaluate(x)[1],
-                      -circular_arc.Evaluate(x)[1]);
-    }
-  }
+  /// Perform Compositions
+  // Polynomial (Rational) [1D -> 2D]
+  const auto circular_composed = rectangle.Compose(circular_arc);
+  // Polynomial (Rational) [2D -> 2D]
+  const auto circle_segment_in_rectangle =
+      rectangle.Compose(circle_segment_small);
+  // Rational (Rational) [2D -> 2D]
+  const auto circle_circle_composition =
+      circle_segment_large.Compose(circle_segment_small);
+  // Rational (Polynomial)
+  const auto rectangle_in_circle_composition =
+      circle_segment_large.Compose(rectangle);
 
-  // Test Addition
-  TEST_F(RationalSplineTestSuite, SplineAdditionTest)
-  {
-    using RationalBezier = RationalBezierSpline<1, Point2D, double>;
-    const RationalBezier circular_arc(degree, ctps, weights);
-    RationalBezier circular_arc_v(degree, ctps, weights);
-    const RationalBezier secondary_spline{degree, ctps2, weights2};
-
-    // Create random evaluation point
-    const std::size_t n_sample_points{10};
-
-    // Adding Splines with the same weights does not elevate degree
-    EXPECT_EQ((circular_arc + circular_arc).GetDegrees(),
-              circular_arc.GetDegrees());
-
-    circular_arc_v += secondary_spline;
-    const auto circular_modified = circular_arc + secondary_spline;
-
-    for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++)
-    {
-      const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
-      EXPECT_FLOAT_EQ(
-          circular_modified.Evaluate(x)[0],
-          circular_arc.Evaluate(x)[0] + secondary_spline.Evaluate(x)[0]);
-      EXPECT_FLOAT_EQ(
-          circular_modified.Evaluate(x)[1],
-          circular_arc.Evaluate(x)[1] + secondary_spline.Evaluate(x)[1]);
-      EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[0],
-                      circular_arc_v.Evaluate(x)[0]);
-      EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[1],
-                      circular_arc_v.Evaluate(x)[1]);
-    }
-  }
-
-  // Test Substraction of Splines
-  TEST_F(RationalSplineTestSuite, SplineSubstractionTest)
-  {
-    using RationalBezier = RationalBezierSpline<1, Point2D, double>;
-    const RationalBezier circular_arc(degree, ctps, weights);
-    RationalBezier circular_arc_v(degree, ctps, weights);
-    const RationalBezier secondary_spline{degree, ctps2, weights2};
-
-    // Create random evaluation point
-    const std::size_t n_sample_points{10};
-
-    // Adding Splines with the same weights does not elevate degree
-    EXPECT_EQ((circular_arc - circular_arc).GetDegrees(),
-              circular_arc.GetDegrees());
-
-    circular_arc_v -= secondary_spline;
-    const auto circular_modified = circular_arc - secondary_spline;
-
-    for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++)
-    {
-      const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
-      EXPECT_FLOAT_EQ(
-          circular_modified.Evaluate(x)[0],
-          circular_arc.Evaluate(x)[0] - secondary_spline.Evaluate(x)[0]);
-      EXPECT_FLOAT_EQ(
-          circular_modified.Evaluate(x)[1],
-          circular_arc.Evaluate(x)[1] - secondary_spline.Evaluate(x)[1]);
-      EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[0],
-                      circular_arc_v.Evaluate(x)[0]);
-      EXPECT_FLOAT_EQ(circular_modified.Evaluate(x)[1],
-                      circular_arc_v.Evaluate(x)[1]);
-    }
-  }
-
-  // Test Multiplication of Splines
-  TEST_F(RationalSplineTestSuite, SplineMultiplicationTest)
-  {
-    using RationalBezier = RationalBezierSpline<1, Point2D, double>;
-    const RationalBezier circular_arc(degree, ctps, weights);
-    const RationalBezier secondary_spline{degree, ctps2, weights2};
-
-    // Create random evaluation point
-    const std::size_t n_sample_points{10};
-
-    const auto circular_modified = circular_arc * secondary_spline;
-
-    for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++)
-    {
-      const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
-      EXPECT_FLOAT_EQ(circular_modified.Evaluate(x),
-                      circular_arc.Evaluate(x) * secondary_spline.Evaluate(x));
-    }
-  }
-
-  // Test Unit Cube Checks
-  TEST_F(RationalSplineTestSuite, CubeCheckSplineTest)
-  {
-    using RationalBezierSurface = RationalBezierSpline<2, Point2D, double>;
-    const RationalBezierSurface circle_segment{degrees_2D, ctps_2D, weights_2D};
-    using RationalBezier = RationalBezierSpline<1, Point2D, double>;
-    const RationalBezier circular_arc(degree, ctps, weights);
-    EXPECT_FLOAT_EQ(circle_segment.MaximumCorner()[0], Point2D(2., 2.)[0]);
-    EXPECT_FLOAT_EQ(circle_segment.MaximumCorner()[1], Point2D(2., 2.)[1]);
-    EXPECT_FLOAT_EQ(circle_segment.MinimumCorner()[0], Point2D(0., 0.)[0]);
-    EXPECT_FLOAT_EQ(circle_segment.MinimumCorner()[1], Point2D(0., 0.)[1]);
-    EXPECT_FALSE(circle_segment.FitsIntoUnitCube());
-    EXPECT_TRUE(circular_arc.FitsIntoUnitCube());
-  }
-
-  // Test Composition of (Rational) splines
-  TEST_F(RationalSplineTestSuite, SplineComposition)
-  {
-    using RationalBezierSurface = RationalBezierSpline<2, Point2D, double>;
-    RationalBezierSurface circle_segment_large =
-        RationalBezierSurface(degrees_2D, ctps_2D, weights_2D);
-    RationalBezierSurface circle_segment_small = circle_segment_large * 0.5;
-    using RationalBezier = RationalBezierSpline<1, Point2D, double>;
-    using BezierSurface = BezierSpline<2, Point2D, double>;
-    const RationalBezier circular_arc(degree, ctps, weights);
-    const BezierSurface rectangle{
-        // degrees
-        std::array<std::size_t, 2>{1, 1},
-        // CTPS
-        std::vector<Point2D>{Point2D{0.5, 0.}, Point2D{1., 0.3}, Point2D{0., 0.3},
-                             Point2D{0.5, 1.}}};
-
-    // Create random evaluation point
-    const std::size_t n_sample_points{5};
-
-    /// Perform Compositions
+  for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++) {
+    // Sample points
+    const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
+    const double y{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
     // Polynomial (Rational) [1D -> 2D]
-    const auto circular_composed = rectangle.Compose(circular_arc);
+    EXPECT_FLOAT_EQ(circular_composed.Evaluate(x)[0],
+                    rectangle.Evaluate(circular_arc.Evaluate(x))[0]);
+    EXPECT_FLOAT_EQ(circular_composed.Evaluate(x)[1],
+                    rectangle.Evaluate(circular_arc.Evaluate(x))[1]);
     // Polynomial (Rational) [2D -> 2D]
-    const auto circle_segment_in_rectangle =
-        rectangle.Compose(circle_segment_small);
+    EXPECT_FLOAT_EQ(circle_segment_in_rectangle.Evaluate(x, y)[0],
+                    rectangle.Evaluate(circle_segment_small.Evaluate(x, y))[0]);
+    EXPECT_FLOAT_EQ(circle_segment_in_rectangle.Evaluate(x, y)[1],
+                    rectangle.Evaluate(circle_segment_small.Evaluate(x, y))[1]);
     // Rational (Rational) [2D -> 2D]
-    const auto circle_circle_composition =
-        circle_segment_large.Compose(circle_segment_small);
-    // Rational (Polynomial)
-    const auto rectangle_in_circle_composition =
-        circle_segment_large.Compose(rectangle);
-
-    for (std::size_t i_sample_y{0}; i_sample_y < n_sample_points; i_sample_y++)
-    {
-      // Sample points
-      const double x{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
-      const double y{static_cast<double>(rand()) / static_cast<double>(RAND_MAX)};
-      // Polynomial (Rational) [1D -> 2D]
-      EXPECT_FLOAT_EQ(circular_composed.Evaluate(x)[0],
-                      rectangle.Evaluate(circular_arc.Evaluate(x))[0]);
-      EXPECT_FLOAT_EQ(circular_composed.Evaluate(x)[1],
-                      rectangle.Evaluate(circular_arc.Evaluate(x))[1]);
-      // Polynomial (Rational) [2D -> 2D]
-      EXPECT_FLOAT_EQ(circle_segment_in_rectangle.Evaluate(x, y)[0],
-                      rectangle.Evaluate(circle_segment_small.Evaluate(x, y))[0]);
-      EXPECT_FLOAT_EQ(circle_segment_in_rectangle.Evaluate(x, y)[1],
-                      rectangle.Evaluate(circle_segment_small.Evaluate(x, y))[1]);
-      // Rational (Rational) [2D -> 2D]
-      EXPECT_FLOAT_EQ(
-          circle_circle_composition.Evaluate(x, y)[0],
-          circle_segment_large.Evaluate(circle_segment_small.Evaluate(x, y))[0]);
-      EXPECT_FLOAT_EQ(
-          circle_circle_composition.Evaluate(x, y)[1],
-          circle_segment_large.Evaluate(circle_segment_small.Evaluate(x, y))[1]);
-      // Rational (Rational) [2D -> 2D]
-      EXPECT_FLOAT_EQ(rectangle_in_circle_composition.Evaluate(x, y)[0],
-                      circle_segment_large.Evaluate(rectangle.Evaluate(x, y))[0]);
-      EXPECT_FLOAT_EQ(rectangle_in_circle_composition.Evaluate(x, y)[1],
-                      circle_segment_large.Evaluate(rectangle.Evaluate(x, y))[1]);
-    }
+    EXPECT_FLOAT_EQ(
+        circle_circle_composition.Evaluate(x, y)[0],
+        circle_segment_large.Evaluate(circle_segment_small.Evaluate(x, y))[0]);
+    EXPECT_FLOAT_EQ(
+        circle_circle_composition.Evaluate(x, y)[1],
+        circle_segment_large.Evaluate(circle_segment_small.Evaluate(x, y))[1]);
+    // Rational (Rational) [2D -> 2D]
+    EXPECT_FLOAT_EQ(rectangle_in_circle_composition.Evaluate(x, y)[0],
+                    circle_segment_large.Evaluate(rectangle.Evaluate(x, y))[0]);
+    EXPECT_FLOAT_EQ(rectangle_in_circle_composition.Evaluate(x, y)[1],
+                    circle_segment_large.Evaluate(rectangle.Evaluate(x, y))[1]);
   }
+}
 
-} // namespace bezman::tests::rational_splines_test
+}  // namespace bezman::tests::rational_splines_test


### PR DESCRIPTION
### Higher order derivatives and bugfix for Fit functions
- solves https://github.com/tataratat/splinepy/issues/299
- you can now compute the close form derivative for Beziers more easily to higher orders directly without copies


# Check list
### Test documentation (delete if not applicable)
* [x]  Build Debug
* [x]  Build Release Mode
* [x]  Executed Tests
* [x]  Build Tests
* [x]  Executed Examples
* [x]  Added new unit test for new feature

### Documentation of changes and theory
* [x]  I have updated the relevant documentations, as far as necessary.

### Style guide compliance
* [x]  Edited `C++` files formatted with clang-format (`10.x.x`+)

